### PR TITLE
Optimize lib-direct and high-depth PNG presentation

### DIFF
--- a/app/src/main/kotlin/com/hippo/ehviewer/Settings.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/Settings.kt
@@ -300,10 +300,11 @@ object Settings : DataStorePreferences(null) {
      * Platform high bit depth for **PNG/APNG** under [readerAdvancedColor].
      *
      * When on **and** advanced color is on: bypass Coil hardware-direct for high-depth
-     * PNG → [BitmapFactory] preferred [Bitmap.Config.RGBA_F16], then linearize + optional
-     * FP16 [HardwareBuffer] wrap (same present path as lib-direct). AVIF/HEIF stay on the
-     * normal platform path. Default off (2× RAM). When WCG/[readerAdvancedColor] changes,
-     * this value is forced to match (WCG drives sub-toggle; sub-toggle never drives WCG).
+     * PNG → [BitmapFactory] preferred [Bitmap.Config.RGBA_F16], preserving its source
+     * [android.graphics.ColorSpace], then optional FP16 [HardwareBuffer] wrap. AVIF/HEIF
+     * stay on the normal platform path. Default off (2× RAM). When
+     * WCG/[readerAdvancedColor] changes, this value is forced to match (WCG drives
+     * sub-toggle; sub-toggle never drives WCG).
      */
     val readerPlatformHighDepth = boolPref("pref_reader_platform_high_depth", false)
 

--- a/app/src/main/kotlin/com/hippo/ehviewer/gallery/PageLoader.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/gallery/PageLoader.kt
@@ -3,12 +3,10 @@ package com.hippo.ehviewer.gallery
 import android.os.Handler
 import android.os.Looper
 import androidx.collection.SieveCache
-import androidx.collection.mutableIntObjectMapOf
 import androidx.compose.runtime.mutableIntStateOf
 import arrow.fx.coroutines.ExitCase
 import arrow.fx.coroutines.bracketCase
 import com.ehviewer.core.model.GalleryInfo
-import com.ehviewer.core.util.withNonCancellableContext
 import com.hippo.ehviewer.EhDB
 import com.hippo.ehviewer.Settings
 import com.hippo.ehviewer.image.ByteBufferSource
@@ -32,6 +30,8 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -83,7 +83,7 @@ abstract class PageLoader(
 
     var startPage = if (size <= 0) 0 else startPage.coerceIn(0, size - 1)
 
-    private val jobs = mutableIntObjectMapOf<Job>()
+    private val jobs = HashMap<Int, Job>()
     private val mutex = NamedMutex<Int>()
 
     /**
@@ -123,16 +123,20 @@ abstract class PageLoader(
         bracketCase(
             { openSource(index) },
             { raw ->
-                withNonCancellableContext {
-                    val checkAds = hasAds && detectAds(index, size)
-                    val image = tryDecodeLibDirect(raw, forceOriginal)
-                        ?: Image.decode(
-                            DisplaySource.ensureReady(raw),
-                            checkExtraneousAds = checkAds,
-                            forceOriginal = forceOriginal,
-                        )
-                    notifyPageSucceed(index, image)
+                val checkAds = hasAds && detectAds(index, size)
+                val image = tryDecodeLibDirect(raw, forceOriginal)
+                    ?: Image.decode(
+                        DisplaySource.ensureReady(raw),
+                        checkExtraneousAds = checkAds,
+                        forceOriginal = forceOriginal,
+                    )
+                try {
+                    currentCoroutineContext().ensureActive()
+                } catch (e: CancellationException) {
+                    image.unpin()
+                    throw e
                 }
+                notifyPageSucceed(index, image)
             },
             { src, case -> if (case !is ExitCase.Completed) src.close() },
         )
@@ -200,8 +204,31 @@ abstract class PageLoader(
     private val prefetchPageCount = Settings.preloadImage.value
 
     fun restart() {
+        cancelDecodeJobs()
         lock.write { cache.evictAll() }
         pages.forEach(Page::reset)
+    }
+
+    /**
+     * Cancel queued/offscreen work before a pager-current request. Native codec calls cannot
+     * be interrupted mid-call, but removing non-cancellable wrapping prevents obsolete jobs
+     * from continuing through bitmap copies and publishing stale results afterward.
+     */
+    private fun prioritizeDecode(index: Int) {
+        val obsolete = synchronized(jobs) {
+            jobs.entries
+                .filter { (jobIndex, job) -> jobIndex != index && job.isActive }
+                .map { it.key to it.value }
+                .also { stale -> stale.forEach { (jobIndex, _) -> jobs.remove(jobIndex) } }
+        }
+        obsolete.forEach { (_, job) -> job.cancel() }
+    }
+
+    private fun cancelDecodeJobs() {
+        val active = synchronized(jobs) {
+            jobs.values.toList().also { jobs.clear() }
+        }
+        active.forEach { it.cancel() }
     }
 
     private val prevIndex = AtomicInt(-1)
@@ -251,6 +278,7 @@ abstract class PageLoader(
     }
 
     override fun close() {
+        cancelDecodeJobs()
         lock.write { cache.evictAll() }
         info?.let { gallery ->
             progressScope.launch {
@@ -268,8 +296,9 @@ abstract class PageLoader(
         FileUtils.sanitizeFilename("$title - ${index + 1}.${it.lowercase()}")
     }
 
-    fun request(index: Int) {
+    fun request(index: Int, prioritize: Boolean = false) {
         if (index !in 0 until size) return
+        if (prioritize) prioritizeDecode(index)
         val prefetchRange = if (index >= prevIndex.load()) {
             index + 1..(index + prefetchPageCount).coerceAtMost(size - 1)
         } else {

--- a/app/src/main/kotlin/com/hippo/ehviewer/image/HardwareF16.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/image/HardwareF16.kt
@@ -4,10 +4,7 @@ import android.graphics.Bitmap
 import android.graphics.ColorSpace
 import android.hardware.HardwareBuffer
 import android.os.Build
-import android.util.Half
 import com.ehviewer.core.util.logcat
-import java.nio.ByteBuffer
-import java.nio.ByteOrder
 
 /**
  * Wrap software [Bitmap.Config.RGBA_F16] into a GPU-sampled HARDWARE bitmap via
@@ -40,131 +37,32 @@ fun tryHardwareF16Wrap(software: Bitmap): Bitmap? {
 }
 
 /**
- * Align platform PNG HBD (BitmapFactory F16) with lib-direct-style present encoding:
- * **linear** half-float, tagged with a **linear** color space that keeps **source primaries**.
+ * Copy packed RGBA_F16 pixels directly into a GPU-sampled [HardwareBuffer], avoiding the
+ * intermediate software Bitmap used by the lib-direct path.
  *
- * Platform preferred-F16 is usually still **gamma-encoded**. We apply the source EOTF
- * (or sRGB EOTF if untagged) then re-tag:
- * - sRGB / non-wide → [ColorSpace.Named.LINEAR_EXTENDED_SRGB] (same as JXL SDR F16)
- * - wide gamut (Display P3, BT.2020, ICC) → **same primaries + white point**, linear transfer
- *
- * Never force LINEAR_EXTENDED_SRGB on BT.2020/P3 pixels — that reinterprets wide primaries
- * as BT.709 and shifts hues (grayscale HBD still looks fine; WCG test charts break).
- *
- * On success recycles [software] when a new bitmap is created. On failure returns [software].
+ * [colorSpace] describes the samples exactly as packed by the native codec: linear extended
+ * sRGB for scRGB, linear BT.2020 for preserved HDR/WCG, or another explicit source space.
+ * No transfer or gamut conversion happens here, so deep color and WCG metadata are preserved.
  */
-fun normalizePlatformHbdToLibDirectF16(software: Bitmap): Bitmap {
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return software
-    if (software.config != Bitmap.Config.RGBA_F16) return software
-    val srcCs = software.colorSpace
-    val dstCs = linearPresentColorSpace(srcCs)
-    // Already linear in the target space — keep (still may AHB-wrap later).
-    if (srcCs != null && srcCs == dstCs) return software
-    if (srcCs is ColorSpace.Rgb && isApproximatelyLinearTransfer(srcCs) &&
-        samePrimaries(srcCs, dstCs)
-    ) {
-        // Linear pixels already; only re-tag if needed for a named / clean CS.
-        return retagF16(software, dstCs) ?: software
-    }
-
+fun tryHardwareF16FromPixels(
+    pixels: ByteArray,
+    width: Int,
+    height: Int,
+    colorSpace: ColorSpace?,
+): Bitmap? {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) return null
+    if (width <= 0 || height <= 0) return null
+    val expected = width.toLong() * height * 8L
+    if (expected > Int.MAX_VALUE || pixels.size.toLong() != expected) return null
     return runCatching {
-        val w = software.width
-        val h = software.height
-        val bytes = w * h * 8
-        val buf = ByteBuffer.allocateDirect(bytes).order(ByteOrder.nativeOrder())
-        software.copyPixelsToBuffer(buf)
-        buf.rewind()
-
-        // Source EOTF (BT.2020 / P3 / sRGB each use their curve); untagged → IEC sRGB.
-        val eotf: (Float) -> Float = when {
-            srcCs is ColorSpace.Rgb && !isApproximatelyLinearTransfer(srcCs) ->
-                { e -> srcCs.eotf.applyAsDouble(e.toDouble()).toFloat() }
-            srcCs is ColorSpace.Rgb -> { e -> e } // already linear samples
-            else -> ::srgbEotf
+        val usage = HardwareBuffer.USAGE_GPU_SAMPLED_IMAGE or HardwareBuffer.USAGE_CPU_WRITE_RARELY
+        val buffer = HardwareBuffer.create(width, height, HardwareBuffer.RGBA_FP16, 1, usage)
+        try {
+            copyByteArrayToAHB(pixels, buffer)
+            Bitmap.wrapHardwareBuffer(buffer, colorSpace)
+                ?: error("wrapHardwareBuffer returned null")
+        } finally {
+            buffer.close()
         }
-
-        val out = ByteBuffer.allocateDirect(bytes).order(ByteOrder.nativeOrder())
-        var i = 0
-        while (i < bytes) {
-            val r = eotf(Half.toFloat(buf.getShort(i)))
-            val g = eotf(Half.toFloat(buf.getShort(i + 2)))
-            val b = eotf(Half.toFloat(buf.getShort(i + 4)))
-            val a = Half.toFloat(buf.getShort(i + 6))
-            out.putShort(i, Half.toHalf(r))
-            out.putShort(i + 2, Half.toHalf(g))
-            out.putShort(i + 4, Half.toHalf(b))
-            out.putShort(i + 6, Half.toHalf(a))
-            i += 8
-        }
-        out.rewind()
-
-        val dst = Bitmap.createBitmap(w, h, Bitmap.Config.RGBA_F16, true, dstCs)
-        dst.copyPixelsFromBuffer(out)
-        dst.prepareToDraw()
-        software.recycle()
-        dst
-    }.onFailure { logcat("HardwareF16", it) }.getOrDefault(software)
-}
-
-/**
- * Linear present CS for HBD F16: keep wide-gamut primaries; sRGB family → extended linear sRGB.
- */
-private fun linearPresentColorSpace(srcCs: ColorSpace?): ColorSpace {
-    val linearSrgb = ColorSpace.get(ColorSpace.Named.LINEAR_EXTENDED_SRGB)
-    if (srcCs !is ColorSpace.Rgb) return linearSrgb
-    // sRGB / scRGB family (including EXTENDED_SRGB gamma)
-    if (srcCs.isSrgb || !srcCs.isWideGamut) return linearSrgb
-    if (isApproximatelyLinearTransfer(srcCs)) return srcCs
-    // Display P3 / BT.2020 / ICC: same primaries + white point, identity transfer.
-    val minV = minOf(srcCs.getMinValue(0), 0f)
-    val maxV = maxOf(srcCs.getMaxValue(0), 1f)
-    return ColorSpace.Rgb(
-        "${srcCs.name}-Linear",
-        srcCs.primaries,
-        srcCs.whitePoint,
-        { x: Double -> x },
-        { x: Double -> x },
-        minV,
-        maxV,
-    )
-}
-
-private fun isApproximatelyLinearTransfer(rgb: ColorSpace.Rgb): Boolean {
-    // Identity EOTF: f(0.5) ≈ 0.5 (gamma ~2.2 gives ~0.22).
-    val mid = rgb.eotf.applyAsDouble(0.5)
-    return kotlin.math.abs(mid - 0.5) < 0.03
-}
-
-private fun samePrimaries(a: ColorSpace, b: ColorSpace): Boolean {
-    if (a !is ColorSpace.Rgb || b !is ColorSpace.Rgb) return a == b
-    val pa = a.primaries
-    val pb = b.primaries
-    if (pa.size != pb.size) return false
-    for (i in pa.indices) {
-        if (kotlin.math.abs(pa[i] - pb[i]) > 1e-3f) return false
-    }
-    return true
-}
-
-/** Copy F16 pixels into a new bitmap with [dstCs] (no sample transform). */
-private fun retagF16(software: Bitmap, dstCs: ColorSpace): Bitmap? = runCatching {
-    if (software.colorSpace == dstCs) return software
-    val w = software.width
-    val h = software.height
-    val bytes = w * h * 8
-    val buf = ByteBuffer.allocateDirect(bytes).order(ByteOrder.nativeOrder())
-    software.copyPixelsToBuffer(buf)
-    buf.rewind()
-    val dst = Bitmap.createBitmap(w, h, Bitmap.Config.RGBA_F16, true, dstCs)
-    dst.copyPixelsFromBuffer(buf)
-    dst.prepareToDraw()
-    software.recycle()
-    dst
-}.onFailure { logcat("HardwareF16", it) }.getOrNull()
-
-/** IEC 61966-2-1 sRGB EOTF (encoded [0,1] → linear). */
-private fun srgbEotf(s: Float): Float {
-    if (!s.isFinite() || s <= 0f) return 0f
-    if (s >= 1f) return 1f
-    return if (s <= 0.04045f) s / 12.92f else Math.pow(((s + 0.055f) / 1.055f).toDouble(), 2.4).toFloat()
+    }.onFailure { logcat("HardwareF16", it) }.getOrNull()
 }

--- a/app/src/main/kotlin/com/hippo/ehviewer/image/Image.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/image/Image.kt
@@ -244,7 +244,7 @@ class Image private constructor(
             /**
              * PNG high bit depth: software [BitmapFactory] + preferred [Bitmap.Config.RGBA_F16]
              * (bypasses Coil hardware-direct / ImageDecoder, which often keep only 8-bit).
-             * Crop/QR off; present step linearizes + AHB-wraps like lib-direct.
+             * Crop/QR off; present step preserves source color metadata and may AHB-wrap.
              */
             platformHbd: Boolean = false,
         ): CoilImage {
@@ -350,15 +350,20 @@ class Image private constructor(
         )
 
         /**
-         * After BitmapFactory F16: linearize (keep source primaries; sRGB → linear extended
-         * sRGB) + optional AHB FP16. Do not force BT.709 on BT.2020/P3 WCG files.
+         * After BitmapFactory F16: preserve decoder samples + source [ColorSpace] unchanged,
+         * then optionally copy once into an FP16 HardwareBuffer. Android performs the tagged
+         * transfer/gamut conversion at draw time; a Kotlin per-pixel linearization is both
+         * redundant and prohibitively expensive for large 16-bit PNGs.
          */
         private fun CoilImage.presentPlatformHbdLikeLibDirect(): CoilImage {
             val bi = asBitmapImage() ?: return this
-            var soft = bi.bitmap
+            val soft = bi.bitmap
             if (soft.config != Bitmap.Config.RGBA_F16) return this
-            soft = normalizePlatformHbdToLibDirectF16(soft)
-            val finalBm = tryHardwareF16Wrap(soft) ?: soft
+            val finalBm = if (Settings.readerHardwareBitmap.value) {
+                tryHardwareF16Wrap(soft) ?: soft
+            } else {
+                soft
+            }
             if (Log.isLoggable("ReaderColor", Log.INFO)) {
                 val cs = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                     finalBm.colorSpace?.name ?: "null"
@@ -545,3 +550,4 @@ private fun ByteArray.indexOfAscii(needle: String, length: Int = size): Int {
 external fun detectBorder(bitmap: Bitmap): IntArray
 external fun hasQrCode(bitmap: Bitmap): Boolean
 external fun copyBitmapToAHB(src: Bitmap, dst: HardwareBuffer, x: Int, y: Int)
+external fun copyByteArrayToAHB(src: ByteArray, dst: HardwareBuffer)

--- a/app/src/main/kotlin/com/hippo/ehviewer/image/hdr/LibDirectDecode.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/image/hdr/LibDirectDecode.kt
@@ -8,7 +8,7 @@ import com.hippo.ehviewer.Settings
 import com.hippo.ehviewer.image.ByteBufferSource
 import com.hippo.ehviewer.image.ImageSource
 import com.hippo.ehviewer.image.PathSource
-import com.hippo.ehviewer.image.tryHardwareF16Wrap
+import com.hippo.ehviewer.image.tryHardwareF16FromPixels
 import com.hippo.ehviewer.jni.decodeAvifBytesToDirect
 import com.hippo.ehviewer.jni.decodeJxlBytesToDirect
 import com.hippo.ehviewer.jni.decodeJxrBytesToDirect
@@ -127,14 +127,18 @@ object LibDirectDecode {
         if (w <= 0 || h <= 0) return null
         val f16 = format == 1
         val colorSpace = resolveColorSpace(f16, gamut, transfer)
-        val software = pixelsToSoftwareBitmap(packed.pixels, w, h, f16, colorSpace) ?: return null
-        // Drop the intermediate Java pixel buffer as soon as the Bitmap owns a copy.
-        // (local ref ends after this function; no extra hold.)
-        val bitmap = if (packed.advanced && f16) {
-            tryHardwareF16Wrap(software) ?: software
+        // Default advanced/F16 path: copy the JNI result straight into a HardwareBuffer.
+        // This removes the ByteArray → software Bitmap → AHB double copy while preserving
+        // the exact linear scRGB/BT.2020 ColorSpace chosen above. Fall back to software on
+        // unsupported devices or when the reader hardware-bitmap preference is disabled.
+        val hardware = if (packed.advanced && f16 && Settings.readerHardwareBitmap.value) {
+            tryHardwareF16FromPixels(packed.pixels, w, h, colorSpace)
         } else {
-            software
+            null
         }
+        val bitmap = hardware
+            ?: pixelsToSoftwareBitmap(packed.pixels, w, h, f16, colorSpace)
+            ?: return null
         val boost = packed.outBoost[0].coerceIn(1f, 64f)
         val wide = gamut == 1 || gamut == 2 ||
             (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && bitmap.colorSpace?.isWideGamut == true)

--- a/app/src/main/kotlin/com/hippo/ehviewer/ui/reader/PagerItem.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/ui/reader/PagerItem.kt
@@ -72,17 +72,20 @@ fun PagerItem(
     modifier: Modifier = Modifier,
     contentModifier: Modifier = Modifier,
     viewportSize: Size = Size.Zero,
+    prioritizeDecode: Boolean = false,
 ) {
     // Do NOT cancelRequest on dispose — that raced with notifySourceReady and left pages
     // in Queued with no active decode job (forever spinner) even when the file was cached.
     // Decodes are semaphore-limited and finish into the memory cache for revisit.
-    LaunchedEffect(page.index, pageLoader) {
-        pageLoader.request(page.index)
+    LaunchedEffect(page.index, pageLoader, prioritizeDecode) {
+        pageLoader.request(page.index, prioritize = prioritizeDecode)
         // Re-request when status falls back to Queued (eviction / restart) or blank Error.
         page.statusFlow.drop(1).collect { status ->
             when (status) {
-                PageStatus.Queued -> pageLoader.request(page.index)
-                is PageStatus.Error -> if (status.message == null) pageLoader.request(page.index)
+                PageStatus.Queued -> pageLoader.request(page.index, prioritize = prioritizeDecode)
+                is PageStatus.Error -> if (status.message == null) {
+                    pageLoader.request(page.index, prioritize = prioritizeDecode)
+                }
                 else -> Unit
             }
         }
@@ -120,7 +123,7 @@ fun PagerItem(
                     // Recycled / dead image still marked Ready — force a clean reload.
                     painter = null
                     pageLoader.notifyPageWait(page.index)
-                    pageLoader.request(page.index)
+                    pageLoader.request(page.index, prioritize = prioritizeDecode)
                     return@LaunchedEffect
                 }
                 painter = image.toPainter()

--- a/app/src/main/kotlin/com/hippo/ehviewer/ui/reader/PagerViewer.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/ui/reader/PagerViewer.kt
@@ -263,6 +263,7 @@ private fun PageContainer(
             pageLoader = pageLoader,
             contentScale = ContentScale.Inside,
             viewportSize = layoutSize,
+            prioritizeDecode = pagerState.currentPage == page.index,
             modifier = Modifier.pointerInput(onTap) {
                 detectTapGestures(onLongPress = onLongClick, onTap = onTap.partially1(null))
             },

--- a/app/src/main/rust/src/ffi/android_o.rs
+++ b/app/src/main/rust/src/ffi/android_o.rs
@@ -4,10 +4,11 @@ use super::android::use_bitmap_content;
 use super::jvm::jni_throwing;
 use crate::img::copy_region::CopyRegion;
 use jni::JNIEnv;
-use jni::objects::JClass;
-use jni::sys::{jint, jobject};
+use jni::objects::{JByteArray, JClass, ReleaseMode};
+use jni::sys::{jbyteArray, jint, jobject};
 use jni_fn::jni_fn;
 use ndk::hardware_buffer::{HardwareBuffer, HardwareBufferUsage};
+use std::slice;
 
 #[jni_fn("com.hippo.ehviewer.image.ImageKt")]
 pub fn copyBitmapToAHB(mut env: JNIEnv, _: JClass, bm: jobject, ahb: jobject, x: jint, y: jint) {
@@ -24,5 +25,47 @@ pub fn copyBitmapToAHB(mut env: JNIEnv, _: JClass, bm: jobject, ahb: jobject, x:
         let result = use_bitmap_content(env, bm, s);
         ahb.unlock()?;
         result
+    })
+}
+
+/// Copy tightly packed RGBA_F16 bytes directly into an RGBA_FP16 HardwareBuffer.
+///
+/// This is the lib-direct fast path: JNI copies each source row into the mapped AHB, so
+/// Kotlin never has to allocate and fill an intermediate software Bitmap first. AHB stride
+/// may be wider than the image, hence the row-wise fallback.
+#[jni_fn("com.hippo.ehviewer.image.ImageKt")]
+pub fn copyByteArrayToAHB(mut env: JNIEnv, _: JClass, src: jbyteArray, ahb: jobject) {
+    let src = unsafe { JByteArray::from_raw(src) };
+    let ahb = unsafe { HardwareBuffer::from_jni(env.get_raw(), ahb) };
+    jni_throwing(&mut env, |env| {
+        let desc = ahb.describe();
+        let row_bytes = desc.width as usize * 8;
+        let required = row_bytes
+            .checked_mul(desc.height as usize)
+            .ok_or_else(|| anyhow::anyhow!("RGBA_F16 buffer size overflow"))?;
+        let source_len = env.get_array_length(&src)? as usize;
+        if source_len < required {
+            return Err(anyhow::anyhow!(
+                "RGBA_F16 source too small: {source_len} < {required}"
+            ));
+        }
+
+        let elements = unsafe { env.get_array_elements(&src, ReleaseMode::NoCopyBack)? };
+        let source = unsafe { slice::from_raw_parts(elements.as_ptr() as *const u8, required) };
+        let ptr = ahb.lock(HardwareBufferUsage::CPU_WRITE_RARELY, None, None)? as *mut u8;
+        if desc.stride == desc.width {
+            let destination = unsafe { slice::from_raw_parts_mut(ptr, required) };
+            destination.copy_from_slice(source);
+        } else {
+            let stride_bytes = desc.stride as usize * 8;
+            for y in 0..desc.height as usize {
+                let destination =
+                    unsafe { slice::from_raw_parts_mut(ptr.add(y * stride_bytes), row_bytes) };
+                let offset = y * row_bytes;
+                destination.copy_from_slice(&source[offset..offset + row_bytes]);
+            }
+        }
+        ahb.unlock()?;
+        Ok(())
     })
 }


### PR DESCRIPTION
## Summary

- remove the Kotlin per-pixel EOTF/retag pass from the high-depth PNG path and preserve BitmapFactory's RGBA_F16 samples plus source ColorSpace
- copy advanced lib-direct RGBA_F16 output straight from the JNI byte array into a stride-aware RGBA_FP16 HardwareBuffer, with the existing software-bitmap fallback
- prioritize the pager's current page and cancel stale decode jobs on navigation, restart, and close so obsolete work cannot publish a late Ready state

## Color behavior

- PNG keeps the platform decoder's original transfer function, primaries, and high-bit-depth samples; Android performs the tagged display conversion
- JXL/JXR/PQ-AVIF keep the existing resolveColorSpace decisions (linear extended sRGB or linear BT.2020 as appropriate)
- no gamut conversion, tone mapping, or bit-depth reduction was added
- hardware wrapping remains controlled by the reader hardware-bitmap preference and falls back safely

## Bottlenecks addressed

- high-depth PNG previously copied the full bitmap twice and ran three Kotlin transfer-function evaluations per pixel
- advanced lib-direct F16 previously copied ByteArray -> software Bitmap -> HardwareBuffer
- the shared serialized heavy-decode gate could leave the visible page behind queued/offscreen work, while non-cancellable jobs could publish after a restart

## Validation

- `git diff --check`
- verified the remote branch is one commit ahead of the current `main` and changes only the eight listed decode/reader files
- local Gradle/Rust validation is unavailable in this workspace (Cargo is absent and the Gradle distribution is not cached)
- repository CI is configured to run rustfmt, Clippy, Spotless, and the release build, but GitHub had not registered a PR-triggered run at the time this draft was opened
