### PR TITLE
Fix color management for modular JXL images

### DIFF
--- a/app/src/main/cpp/jxl_hdr.cpp
+++ b/app/src/main/cpp/jxl_hdr.cpp
@@ -1,8 +1,9 @@
 /*
  * JPEG XL → one linear RGBA_F16 working contract via libjxl's CMS.
  *
- * The decoder CMS owns transfer + gamut conversion for both XYB and original-
- * profile/modular images. This file never applies a second manual EOTF.
+ * libjxl's decoder CMS owns XYB conversion. Original-profile/modular images use
+ * an explicit skcms pass because libjxl 0.11.1 leaves those float samples encoded.
+ * Neither path applies a second manual EOTF.
  *
  * JNI: com.hippo.ehviewer.jni.HdrConvertKt.convertJxlBytesToUltraHdr
  */
@@ -22,6 +23,7 @@
 #include <jxl/resizable_parallel_runner_cxx.h>
 
 #include "hdr_encode.h"
+#include "skcms.h"
 #include "ultrahdr_api.h"
 
 #define LOG_TAG "JxlHdr"
@@ -63,6 +65,63 @@ void set_linear_rgb(JxlColorEncoding* enc, JxlPrimaries primaries) {
     enc->primaries = primaries;
     enc->transfer_function = JXL_TRANSFER_FUNCTION_LINEAR;
     enc->rendering_intent = JXL_RENDERING_INTENT_RELATIVE;
+}
+
+/** Build the linear RGB profile matching the gamut handed to the shared encoder/packer. */
+bool make_linear_output_profile(uhdr_color_gamut_t cg, skcms_ICCProfile* profile) {
+    if (!profile) return false;
+    skcms_Init(profile);
+    skcms_SetTransferFunction(profile, skcms_Identity_TransferFunction());
+
+    skcms_Matrix3x3 to_xyz_d50{};
+    bool have_matrix = false;
+    if (cg == UHDR_CG_BT_709) {
+        const skcms_ICCProfile* srgb = skcms_sRGB_profile();
+        if (srgb && srgb->has_toXYZD50) {
+            to_xyz_d50 = srgb->toXYZD50;
+            have_matrix = true;
+        }
+    } else if (cg == UHDR_CG_DISPLAY_P3) {
+        have_matrix = skcms_PrimariesToXYZD50(0.680f, 0.320f, 0.265f, 0.690f, 0.150f,
+                                               0.060f, 0.3127f, 0.3290f, &to_xyz_d50);
+    } else if (cg == UHDR_CG_BT_2100) {
+        have_matrix = skcms_PrimariesToXYZD50(0.708f, 0.292f, 0.170f, 0.797f, 0.131f,
+                                               0.046f, 0.3127f, 0.3290f, &to_xyz_d50);
+    }
+    if (!have_matrix) return false;
+    skcms_SetXYZD50(profile, &to_xyz_d50);
+    return skcms_MakeUsableAsDestination(profile);
+}
+
+/**
+ * libjxl 0.11.1 does not run its requested output CMS stage for modular / lossless
+ * codestreams (`uses_original_profile=true`): their color transform is kNone, so
+ * float output remains in the original encoded transfer function. Run the same
+ * source ICC to linear-working-gamut conversion explicitly for those frames.
+ */
+bool transform_original_profile_to_linear(std::vector<float>& rgba, size_t npx,
+                                          const std::vector<uint8_t>& source_icc,
+                                          uhdr_color_gamut_t cg) {
+    if (npx == 0 || rgba.size() < npx * 4 || source_icc.empty()) return false;
+
+    skcms_ICCProfile src{};
+    if (!skcms_Parse(source_icc.data(), source_icc.size(), &src)) {
+        ALOGE("JXL original ICC parse failed (%zu B)", source_icc.size());
+        return false;
+    }
+    skcms_ICCProfile dst{};
+    if (!make_linear_output_profile(cg, &dst)) {
+        ALOGE("JXL linear destination profile failed cg=%d", (int)cg);
+        return false;
+    }
+    if (!skcms_Transform(rgba.data(), skcms_PixelFormat_RGBA_ffff,
+                         skcms_AlphaFormat_Unpremul, &src, rgba.data(),
+                         skcms_PixelFormat_RGBA_ffff, skcms_AlphaFormat_Unpremul, &dst, npx)) {
+        ALOGE("JXL original-profile CMS transform failed cg=%d", (int)cg);
+        return false;
+    }
+    ALOGI("JXL original-profile CMS applied (%zu B) cg=%d", source_icc.size(), (int)cg);
+    return true;
 }
 
 /** Pick a known linear destination; [out_cg] always names the resulting samples. */
@@ -130,6 +189,7 @@ int decode_jxl_to_linear_f16(const uint8_t* data, size_t len, std::vector<uint16
     bool is_pq = false;
     bool is_hlg = false;
     uhdr_color_gamut_t cg = UHDR_CG_BT_709;
+    std::vector<uint8_t> source_icc;
     std::vector<float> pixels;
     JxlPixelFormat format = {4, JXL_TYPE_FLOAT, JXL_NATIVE_ENDIAN, 0};
 
@@ -161,10 +221,28 @@ int decode_jxl_to_linear_f16(const uint8_t* data, size_t len, std::vector<uint16
             JxlColorEncoding linear_output{};
             choose_linear_output(have_src ? &src_encoding : nullptr, have_src, is_pq, is_hlg,
                                  &linear_output, &cg);
-            if (JxlDecoderSetOutputColorProfile(dec.get(), &linear_output, nullptr, 0) !=
-                JXL_DEC_SUCCESS) {
-                ALOGE("libjxl cannot convert source profile to linear output");
-                return -9;
+
+            // TARGET_DATA incorrectly remains the original profile for modular images in
+            // libjxl 0.11.1, so retain TARGET_ORIGINAL for the explicit transform below.
+            if (info.uses_original_profile) {
+                size_t icc_size = 0;
+                if (JxlDecoderGetICCProfileSize(dec.get(), JXL_COLOR_PROFILE_TARGET_ORIGINAL,
+                                                &icc_size) == JXL_DEC_SUCCESS &&
+                    icc_size > 0 && icc_size <= 16u * 1024u * 1024u) {
+                    source_icc.resize(icc_size);
+                    if (JxlDecoderGetColorAsICCProfile(
+                            dec.get(), JXL_COLOR_PROFILE_TARGET_ORIGINAL, source_icc.data(),
+                            source_icc.size()) != JXL_DEC_SUCCESS) {
+                        source_icc.clear();
+                    }
+                }
+            }
+            if (!info.uses_original_profile) {
+                if (JxlDecoderSetOutputColorProfile(dec.get(), &linear_output, nullptr, 0) !=
+                    JXL_DEC_SUCCESS) {
+                    ALOGE("libjxl cannot convert source profile to linear output");
+                    return -9;
+                }
             }
             if (out_cg) *out_cg = cg;
         } else if (status == JXL_DEC_NEED_IMAGE_OUT_BUFFER) {
@@ -186,6 +264,15 @@ int decode_jxl_to_linear_f16(const uint8_t* data, size_t len, std::vector<uint16
 
     if (pixels.empty() || w == 0 || h == 0) return -12;
 
+    const size_t pixels_n = static_cast<size_t>(w) * static_cast<size_t>(h);
+    const bool original_profile = info.uses_original_profile == JXL_TRUE;
+    if (original_profile &&
+        !transform_original_profile_to_linear(pixels, pixels_n, source_icc, cg)) {
+        // Continuing would reinterpret encoded sRGB/P3/etc. as linear and produce the
+        // washed-out, desaturated regression this path is intended to prevent.
+        return -13;
+    }
+
     // BasicInfo.intensity_target: libjxl default for SDR is **255** nits — NOT HDR.
     const float intensity = info.intensity_target;
     const bool intensity_hdr = std::isfinite(intensity) && intensity >= 400.f;
@@ -201,13 +288,15 @@ int decode_jxl_to_linear_f16(const uint8_t* data, size_t len, std::vector<uint16
         }
     }
 
-    const size_t pixels_n = static_cast<size_t>(w) * static_cast<size_t>(h);
     out_rgba.resize(pixels_n * 4);
 
     // CMS output is normalized linear RGB. Preserve absolute HDR headroom using
     // the codestream intensity target; SDR's common 255-nit metadata stays 1.0.
     float scale = 1.f;
-    if (declared_hdr) {
+    if (declared_hdr && original_profile && is_pq) {
+        // skcms PQ linear output is relative to 10,000 nits, not intensity_target.
+        scale = kMaxLinear;
+    } else if (declared_hdr && !(original_profile && is_hlg)) {
         float peak_nits = intensity;
         if (!std::isfinite(peak_nits) || peak_nits < 1.f) peak_nits = 1000.f;
         scale = peak_nits / kSdrWhiteNits;
@@ -247,8 +336,9 @@ int decode_jxl_to_linear_f16(const uint8_t* data, size_t len, std::vector<uint16
         out_rgba[i * 4 + 3] = float_to_half(a);
     }
 
-    ALOGI("JXL CMS %ux%u cg=%d pq=%d hlg=%d intensity=%.1f scale=%.3f hdr=%d composite=%d",
-          w, h, (int)cg, is_pq ? 1 : 0, is_hlg ? 1 : 0, intensity, scale,
+    ALOGI("JXL CMS %ux%u cg=%d pq=%d hlg=%d original=%d intensity=%.1f scale=%.3f hdr=%d "
+          "composite=%d",
+          w, h, (int)cg, is_pq ? 1 : 0, is_hlg ? 1 : 0, original_profile ? 1 : 0, intensity, scale,
           declared_hdr ? 1 : 0, composite_alpha_on_black ? 1 : 0);
     return 0;
 }


### PR DESCRIPTION
## Summary

- retain the original ICC profile for modular/lossless JXL images
- run those encoded float samples through skcms into the selected linear working gamut
- keep XYB images on libjxl's internal CMS path
- preserve the shared linear-F16 contract used by both JPEG conversion and direct bitmap output

## Root cause

Commit `ee3d994631e8a1d232aa02c35f526536afdd7f95` began requesting linear CMS output from libjxl. In libjxl 0.11.1, modular codestreams (`uses_original_profile=true`) use the `kNone` color-transform path, which does not install the requested CMS stage. Their sRGB/P3/etc. samples therefore remained gamma-encoded but were handed to the rest of the app as linear. The later sRGB OETF/bitmap color-space handling produced the flat, desaturated result in both output routes.

## Validation

- `git diff --check`
- verified the branch is one commit ahead of current `main`, with only `app/src/main/cpp/jxl_hdr.cpp` changed
- compiled and ran an skcms smoke test against the pinned libjxl 0.11.1 skcms source; sRGB values `0.5, 0.25, 0.75` converted to linear `0.21399, 0.05086, 0.52248`

Full Android/Gradle build was not run in this container because its Java executable cannot load `libjli.so`.