### PR TITLE
Stream external videos over loopback HTTP

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -53,6 +53,12 @@
         </intent>
         <intent>
             <action android:name="android.intent.action.VIEW" />
+            <data
+                android:mimeType="video/*"
+                android:scheme="http" />
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
             <data android:mimeType="video/mp4" />
         </intent>
         <intent>
@@ -176,7 +182,7 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/filepaths" />
         </provider>
-        <!-- Range-backed stream for external viewers (PDF / video open-with). -->
+        <!-- Range-backed stream for external viewers (PDF / non-video open-with). -->
         <provider
             android:name="com.hippo.ehviewer.provider.StreamDocumentProvider"
             android:authorities="${applicationId}.streamdoc"

--- a/app/src/main/kotlin/com/hippo/ehviewer/Settings.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/Settings.kt
@@ -103,6 +103,13 @@ object Settings : DataStorePreferences(null) {
     val defaultVideoPlayerComponent = stringPref("default_video_player_component", "")
 
     /**
+     * When true, external HTTP video open exposes **all** videos and subtitle files in the
+     * current directory (playlist / next-prev friendly). When false (default), only the
+     * opened video plus matching sidecar subs are published. Settings → General.
+     */
+    val externalVideoAccessDir = boolPref("external_video_access_dir", false)
+
+    /**
      * When true, folder-view shows folder galleries below [browseSmallGalleryMinPages].
      * Default false: UI hides those rows (scanner listing is unchanged).
      */

--- a/app/src/main/kotlin/com/hippo/ehviewer/library/MediaTypes.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/library/MediaTypes.kt
@@ -201,6 +201,11 @@ fun mimeTypeForFileName(name: String): String {
         }
         else -> when (ext) {
             "txt" -> "text/plain"
+            "srt" -> "application/x-subrip"
+            "ass", "ssa" -> "text/x-ssa"
+            "vtt" -> "text/vtt"
+            "smi", "sami" -> "application/smil+xml"
+            "sub" -> "text/x-microdvd"
             "json" -> "application/json"
             "xml" -> "application/xml"
             "html", "htm" -> "text/html"

--- a/app/src/main/kotlin/com/hippo/ehviewer/library/SidecarSubtitles.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/library/SidecarSubtitles.kt
@@ -1,0 +1,97 @@
+package com.hippo.ehviewer.library
+
+import com.hippo.ehviewer.util.FileUtils
+
+/**
+ * Sidecar subtitle discovery for external video open.
+ *
+ * Matches files in the same directory as the video:
+ * - `movie.srt` / `movie.ass` / …
+ * - `movie.en.srt`, `movie.zh-CN.ass`, … (basename + tags before extension)
+ */
+object SidecarSubtitles {
+    private val EXTENSIONS = setOf(
+        "srt",
+        "ass",
+        "ssa",
+        "vtt",
+        "sub",
+        "smi",
+        "sami",
+        "txt",
+    )
+
+    /** Language / region tags probed when directory listing is unavailable (network). */
+    private val PROBE_TAGS = listOf(
+        "",
+        ".en", ".eng", ".en-US", ".en-GB",
+        ".zh", ".zh-CN", ".zh-TW", ".zh-HK",
+        ".chs", ".cht", ".sc", ".tc", ".chi",
+        ".ja", ".jp", ".jpn",
+        ".ko", ".kor",
+        ".es", ".fr", ".de", ".ru", ".pt", ".it",
+    )
+
+    fun isSubtitleFileName(name: String): Boolean {
+        if (name.startsWith('.')) return false
+        val ext = FileUtils.getExtensionFromFilename(name)?.lowercase() ?: return false
+        return ext in EXTENSIONS
+    }
+
+    fun mimeTypeForSubtitle(name: String): String {
+        val ext = FileUtils.getExtensionFromFilename(name)?.lowercase() ?: return "application/x-subrip"
+        return when (ext) {
+            "srt" -> "application/x-subrip"
+            "ass", "ssa" -> "text/x-ssa"
+            "vtt" -> "text/vtt"
+            "smi", "sami" -> "application/smil+xml"
+            "sub" -> "text/x-microdvd"
+            "txt" -> "text/plain"
+            else -> "application/octet-stream"
+        }
+    }
+
+    /**
+     * True if [fileName] is a sidecar for video [videoName]
+     * (`movie.srt` or `movie.*.srt` matching stem `movie`).
+     */
+    fun isSidecarFor(videoName: String, fileName: String): Boolean {
+        if (!isSubtitleFileName(fileName)) return false
+        val videoStem = stem(videoName) ?: return false
+        val subStem = stem(fileName) ?: return false
+        return subStem.equals(videoStem, ignoreCase = true) ||
+            subStem.startsWith("$videoStem.", ignoreCase = true) ||
+            subStem.startsWith("$videoStem ", ignoreCase = true)
+    }
+
+    /** Filter sibling basenames that pair with [videoName]. Sorted by name. */
+    fun matchSiblings(videoName: String, siblingNames: Collection<String>): List<String> = siblingNames
+        .asSequence()
+        .filter { isSidecarFor(videoName, it) }
+        .distinctBy { it.lowercase() }
+        .sortedWith(String.CASE_INSENSITIVE_ORDER)
+        .toList()
+
+    /**
+     * Candidate basenames to probe when we cannot list the directory
+     * (exact stem + common language tags × subtitle extensions).
+     */
+    fun probeCandidateNames(videoName: String): List<String> {
+        val videoStem = stem(videoName) ?: return emptyList()
+        return buildList {
+            for (tag in PROBE_TAGS) {
+                for (ext in EXTENSIONS) {
+                    // Skip bare .txt without a language tag — too many false positives.
+                    if (ext == "txt" && tag.isEmpty()) continue
+                    add("$videoStem$tag.$ext")
+                }
+            }
+        }
+    }
+
+    private fun stem(name: String): String? {
+        val base = name.substringAfterLast('/').substringAfterLast('\\')
+        if (base.isEmpty() || !base.contains('.')) return null
+        return base.substringBeforeLast('.')
+    }
+}

--- a/app/src/main/kotlin/com/hippo/ehviewer/provider/ExternalHttpStreamServer.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/provider/ExternalHttpStreamServer.kt
@@ -1,0 +1,607 @@
+package com.hippo.ehviewer.provider
+
+import android.content.Context
+import android.net.Uri
+import android.os.ParcelFileDescriptor
+import android.os.SystemClock
+import com.ehviewer.core.util.logcat
+import com.hippo.ehviewer.library.ArchiveByteSource
+import com.hippo.ehviewer.library.mimeTypeForFileName
+import java.io.BufferedInputStream
+import java.io.BufferedOutputStream
+import java.io.File
+import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
+import java.io.RandomAccessFile
+import java.net.InetAddress
+import java.net.ServerSocket
+import java.net.Socket
+import java.net.URLDecoder
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.SynchronousQueue
+import java.util.concurrent.ThreadPoolExecutor
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import splitties.init.appCtx
+
+/**
+ * Loopback HTTP server for **external** video open (MX / VLC / mpv).
+ *
+ * Same idea as SMB file explorers:
+ * `http://127.0.0.1:{port}/s/{sessionId}/{fileName}`
+ *
+ * Players auto-load sidecars by requesting a sibling URL (swap extension). That does not
+ * work with `content://` streamdoc grants; HTTP does.
+ *
+ * - Binds **127.0.0.1 only** (device-local; other apps on the phone can still connect).
+ * - Supports **Range** for seek.
+ * - Optional [Session.resolveSibling] serves invented names (e.g. `.srt` when only `.ass`
+ *   was pre-registered) from the same remote/local parent directory.
+ */
+object ExternalHttpStreamServer {
+    data class FileEntry(
+        val displayName: String,
+        val mimeType: String,
+        val sizeBytes: Long,
+        /** Open a fresh random-access source for this response (may be called per Range). */
+        val open: () -> StreamBody,
+    )
+
+    sealed interface StreamBody : AutoCloseable {
+        val size: Long
+        fun readAt(offset: Long, buf: ByteArray, off: Int, len: Int): Int
+    }
+
+    class ArchiveBody(private val source: ArchiveByteSource) : StreamBody {
+        override val size: Long get() = source.size
+        override fun readAt(offset: Long, buf: ByteArray, off: Int, len: Int): Int = source.readAt(offset, buf, off, len)
+        override fun close() = source.close()
+    }
+
+    class LocalFileBody(private val file: File) : StreamBody {
+        private val raf = RandomAccessFile(file, "r")
+        override val size: Long get() = raf.length()
+        override fun readAt(offset: Long, buf: ByteArray, off: Int, len: Int): Int {
+            if (len <= 0) return 0
+            if (offset >= size) return 0
+            raf.seek(offset)
+            val n = raf.read(buf, off, minOf(len, (size - offset).toInt()))
+            return if (n < 0) 0 else n
+        }
+        override fun close() = raf.close()
+    }
+
+    class PfdBody(private val pfd: ParcelFileDescriptor) : StreamBody {
+        private val stream = ParcelFileDescriptor.AutoCloseInputStream(pfd)
+        private val channel = stream.channel
+        override val size: Long get() = channel.size()
+        override fun readAt(offset: Long, buf: ByteArray, off: Int, len: Int): Int {
+            if (len <= 0) return 0
+            if (offset >= size) return 0
+            val want = minOf(len.toLong(), size - offset).toInt()
+            val bb = java.nio.ByteBuffer.wrap(buf, off, want)
+            val n = channel.read(bb, offset)
+            return if (n < 0) 0 else n
+        }
+        override fun close() {
+            runCatching { stream.close() }
+        }
+    }
+
+    class Session(
+        val id: String,
+        val network: Boolean,
+        val files: ConcurrentHashMap<String, FileEntry> = ConcurrentHashMap(),
+        /**
+         * On-demand open for a sibling basename not yet in [files]
+         * (player invents `movie.srt` under the same virtual dir).
+         */
+        @Volatile var resolveSibling: ((String) -> FileEntry?)? = null,
+        @Volatile var lastAccessMs: Long = SystemClock.elapsedRealtime(),
+    ) {
+        fun touch() {
+            lastAccessMs = SystemClock.elapsedRealtime()
+        }
+
+        fun put(entry: FileEntry) {
+            files[pathKey(entry.displayName)] = entry
+            touch()
+        }
+
+        fun get(fileName: String): FileEntry? {
+            touch()
+            if (!isSafeFileName(fileName)) return null
+            val key = fileName.trim()
+            files[key]?.let { return it }
+            // Case-insensitive fallback for odd players.
+            files.entries.firstOrNull { it.key.equals(key, ignoreCase = true) }?.value?.let {
+                return it
+            }
+            val resolved = resolveSibling?.invoke(fileName) ?: return null
+            files[pathKey(resolved.displayName)] = resolved
+            return resolved
+        }
+    }
+
+    private val sessions = ConcurrentHashMap<String, Session>()
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private val connectionPool = ThreadPoolExecutor(
+        0,
+        MAX_CONCURRENT_CONNECTIONS,
+        60L,
+        TimeUnit.SECONDS,
+        SynchronousQueue(),
+        { runnable -> Thread(runnable, "ext-http-stream").apply { isDaemon = true } },
+        ThreadPoolExecutor.AbortPolicy(),
+    )
+
+    private val lock = Any()
+    private var serverSocket: ServerSocket? = null
+    private var acceptThread: Thread? = null
+
+    @Volatile
+    private var port: Int = -1
+
+    private val activeTransfers = AtomicInteger(0)
+    private val keepAliveLock = Any()
+    private var stopKeepAliveJob: Job? = null
+    private var pruneJob: Job? = null
+
+    /** Live network transfers + presence of network sessions (for FGS / screen-on). */
+    fun networkActivityCount(): Int {
+        val transfers = activeTransfers.get()
+        val networkSessions = sessions.values.count { it.network }
+        return transfers + networkSessions
+    }
+
+    fun ensureStarted(): Int = synchronized(lock) {
+        serverSocket?.let { return port }
+        val ss = ServerSocket(0, 50, InetAddress.getByName("127.0.0.1"))
+        port = ss.localPort
+        serverSocket = ss
+        acceptThread = Thread(
+            {
+                try {
+                    while (!ss.isClosed) {
+                        val socket = try {
+                            ss.accept()
+                        } catch (_: Throwable) {
+                            break
+                        }
+                        runCatching {
+                            connectionPool.execute { handleClient(socket) }
+                        }.onFailure {
+                            // Bound loopback resource use if another local app floods the port.
+                            runCatching { socket.close() }
+                        }
+                    }
+                } catch (e: Throwable) {
+                    logcat("ExtHttp", e)
+                }
+            },
+            "ext-http-accept",
+        ).apply {
+            isDaemon = true
+            start()
+        }
+        logcat("ExtHttp") { "loopback HTTP listening on 127.0.0.1:$port" }
+        port
+    }
+
+    fun newSession(network: Boolean): Session {
+        ensureStarted()
+        val id = UUID.randomUUID().toString().replace("-", "")
+        val session = Session(id = id, network = network)
+        sessions[id] = session
+        if (network) {
+            onNetworkSessionRegistered()
+        }
+        schedulePrune()
+        return session
+    }
+
+    fun removeSession(id: String) {
+        sessions.remove(id)
+        schedulePrune()
+        maybeStopKeepAliveLater()
+    }
+
+    fun uriFor(sessionId: String, fileName: String): Uri {
+        val p = ensureStarted()
+        val encoded = Uri.encode(pathKey(fileName))
+        return Uri.parse("http://127.0.0.1:$p/s/$sessionId/$encoded")
+    }
+
+    fun pathKey(displayName: String): String {
+        val base = displayName.replace('\\', '/').substringAfterLast('/').trim()
+        return base.ifEmpty { "file" }
+    }
+
+    /** A resolver may only receive one ordinary file-name component. */
+    fun isSafeFileName(fileName: String): Boolean {
+        val name = fileName.trim()
+        return name.isNotEmpty() &&
+            name.length <= MAX_FILE_NAME_LENGTH &&
+            name != "." &&
+            name != ".." &&
+            name.none { it == '/' || it == '\\' || it == '\u0000' || it == '\r' || it == '\n' }
+    }
+
+    // region keep-alive
+
+    private fun onNetworkSessionRegistered(context: Context = appCtx) {
+        synchronized(keepAliveLock) {
+            stopKeepAliveJob?.cancel()
+            stopKeepAliveJob = null
+            StreamKeepAliveService.start(context)
+        }
+    }
+
+    private fun onTransferStarted(network: Boolean, context: Context = appCtx) {
+        if (!network) return
+        activeTransfers.incrementAndGet()
+        synchronized(keepAliveLock) {
+            stopKeepAliveJob?.cancel()
+            stopKeepAliveJob = null
+            StreamKeepAliveService.start(context)
+        }
+    }
+
+    private fun onTransferEnded(network: Boolean) {
+        if (!network) return
+        activeTransfers.updateAndGet { (it - 1).coerceAtLeast(0) }
+        if (activeTransfers.get() == 0) {
+            StreamKeepAliveService.onNetworkIdle()
+            maybeStopKeepAliveLater()
+        }
+    }
+
+    private fun maybeStopKeepAliveLater(context: Context = appCtx) {
+        synchronized(keepAliveLock) {
+            stopKeepAliveJob?.cancel()
+            stopKeepAliveJob = scope.launch {
+                delay(StreamKeepAlivePolicy.fgsStopDelayMs())
+                synchronized(keepAliveLock) {
+                    if (activeTransfers.get() == 0 && sessions.values.none { it.network }) {
+                        // Only stop if streamdoc also idle.
+                        if (StreamDocumentRegistry.networkOpenCount() == 0) {
+                            StreamKeepAliveService.stop(context)
+                        }
+                        stopKeepAliveJob = null
+                    }
+                }
+            }
+        }
+    }
+
+    private fun schedulePrune(nowMs: Long = SystemClock.elapsedRealtime()) {
+        val maxAge = StreamKeepAlivePolicy.tokenMaxAgeMs()
+        val next = sessions.values.minOfOrNull { maxAge - (nowMs - it.lastAccessMs) }
+            ?.coerceAtLeast(1L)
+        pruneJob?.cancel()
+        pruneJob = next?.let { delayMs ->
+            scope.launch {
+                delay(delayMs)
+                pruneStale()
+                schedulePrune()
+            }
+        }
+    }
+
+    fun pruneStale(nowMs: Long = SystemClock.elapsedRealtime()) {
+        val maxAge = StreamKeepAlivePolicy.tokenMaxAgeMs()
+        for ((id, session) in sessions) {
+            if (nowMs - session.lastAccessMs >= maxAge) {
+                sessions.remove(id, session)
+            }
+        }
+        // Soft cap
+        if (sessions.size > MAX_SESSIONS) {
+            val overflow = sessions.size - MAX_SESSIONS
+            sessions.entries
+                .sortedBy { it.value.lastAccessMs }
+                .take(overflow)
+                .forEach { sessions.remove(it.key, it.value) }
+        }
+        maybeStopKeepAliveLater()
+    }
+
+    // endregion
+
+    private fun handleClient(socket: Socket) {
+        try {
+            socket.soTimeout = REQUEST_TIMEOUT_MS
+            val input = BufferedInputStream(socket.getInputStream())
+            val output = BufferedOutputStream(socket.getOutputStream())
+            val request = readRequest(input) ?: run {
+                writeSimple(output, 400, "Bad Request")
+                return
+            }
+            when (request.method) {
+                "GET", "HEAD" -> serve(request, output, headOnly = request.method == "HEAD")
+                else -> writeSimple(output, 405, "Method Not Allowed")
+            }
+            output.flush()
+        } catch (e: Throwable) {
+            if (e !is IOException) logcat("ExtHttp", e)
+        } finally {
+            runCatching { socket.close() }
+        }
+    }
+
+    private data class HttpRequest(
+        val method: String,
+        val path: String,
+        val headers: Map<String, String>,
+    )
+
+    private fun readRequest(input: InputStream): HttpRequest? {
+        val line = readLine(input, MAX_REQUEST_LINE_LENGTH) ?: return null
+        val parts = line.split(' ', limit = 3)
+        if (parts.size != 3 || !parts[2].startsWith("HTTP/")) return null
+        val method = parts[0].uppercase()
+        val path = parts[1]
+        val headers = LinkedHashMap<String, String>()
+        var headerCount = 0
+        while (true) {
+            val h = readLine(input, MAX_HEADER_LINE_LENGTH) ?: return null
+            if (h.isEmpty()) break
+            if (++headerCount > MAX_HEADER_COUNT) return null
+            val colon = h.indexOf(':')
+            if (colon > 0) {
+                val name = h.substring(0, colon).trim().lowercase()
+                val value = h.substring(colon + 1).trim()
+                headers[name] = value
+            }
+        }
+        return HttpRequest(method, path, headers)
+    }
+
+    private fun readLine(input: InputStream, maxLength: Int): String? {
+        val sb = StringBuilder()
+        while (true) {
+            val c = input.read()
+            if (c < 0) return if (sb.isEmpty()) null else sb.toString()
+            if (c == '\n'.code) break
+            if (c != '\r'.code) {
+                if (sb.length >= maxLength) return null
+                sb.append(c.toChar())
+            }
+        }
+        return sb.toString()
+    }
+
+    private fun serve(request: HttpRequest, output: OutputStream, headOnly: Boolean) {
+        // /s/{sessionId}[/] → directory index of registered media
+        // /s/{sessionId}/{fileName} → file body (Range)
+        val rawPath = request.path.substringBefore('?')
+        val segs = runCatching {
+            rawPath.trim('/').split('/').map { URLDecoder.decode(it, Charsets.UTF_8) }
+        }.getOrElse {
+            writeSimple(output, 400, "Bad Request")
+            return
+        }
+        if (segs.isEmpty() || segs[0] != "s") {
+            writeSimple(output, 404, "Not Found")
+            return
+        }
+        if (segs.size == 1) {
+            writeSimple(output, 404, "Not Found")
+            return
+        }
+        val sessionId = segs[1]
+        val session = sessions[sessionId]
+        if (session == null) {
+            writeSimple(output, 404, "Session expired")
+            return
+        }
+        session.touch()
+        // Directory listing (players / next-prev that probe the parent URL).
+        if (segs.size == 2 || (segs.size == 3 && segs[2].isEmpty())) {
+            writeDirectoryListing(output, session, headOnly)
+            return
+        }
+        if (segs.size != 3 || !isSafeFileName(segs[2])) {
+            writeSimple(output, 404, "Not Found")
+            return
+        }
+        val fileName = segs[2]
+        val entry = session.get(fileName)
+        if (entry == null) {
+            logcat("ExtHttp") { "404 missing file session=$sessionId name=$fileName" }
+            writeSimple(output, 404, "Not Found")
+            return
+        }
+
+        val rangeHeader = request.headers["range"]
+        val total = entry.sizeBytes
+        if (total < 1L) {
+            writeSimple(output, 404, "Empty")
+            return
+        }
+
+        val range = parseRange(rangeHeader, total)
+        if (!rangeHeader.isNullOrBlank() && range == null) {
+            writeSimple(
+                output,
+                416,
+                "Range Not Satisfiable",
+                extraHeaders = listOf("Content-Range: bytes */$total"),
+            )
+            return
+        }
+        val start = range?.first ?: 0L
+        val end = range?.second ?: (total - 1L)
+        if (start < 0L || end < start || start >= total) {
+            writeSimple(
+                output,
+                416,
+                "Range Not Satisfiable",
+                extraHeaders = listOf(
+                    "Content-Range: bytes */$total",
+                ),
+            )
+            return
+        }
+        val contentLength = end - start + 1L
+        val status = if (range != null) 206 else 200
+        val statusText = if (range != null) "Partial Content" else "OK"
+        val mime = entry.mimeType.ifBlank { mimeTypeForFileName(entry.displayName) }
+
+        val headers = buildString {
+            append("HTTP/1.1 $status $statusText\r\n")
+            append("Content-Type: $mime\r\n")
+            append("Accept-Ranges: bytes\r\n")
+            append("Content-Length: $contentLength\r\n")
+            if (range != null) {
+                append("Content-Range: bytes $start-$end/$total\r\n")
+            }
+            // Real file name for players that read Content-Disposition.
+            append("Content-Disposition: inline; filename=\"${escapeHeader(entry.displayName)}\"\r\n")
+            append("Connection: close\r\n")
+            append("Cache-Control: no-store\r\n")
+            append("\r\n")
+        }
+        output.write(headers.toByteArray(Charsets.US_ASCII))
+        if (headOnly) return
+
+        onTransferStarted(session.network)
+        try {
+            entry.open().use { body ->
+                val buf = ByteArray(64 * 1024)
+                var remaining = contentLength
+                var offset = start
+                while (remaining > 0L) {
+                    val want = minOf(buf.size.toLong(), remaining).toInt()
+                    val n = body.readAt(offset, buf, 0, want)
+                    if (n <= 0) break
+                    output.write(buf, 0, n)
+                    offset += n
+                    remaining -= n
+                    session.touch()
+                }
+            }
+        } catch (e: Throwable) {
+            if (e !is IOException) logcat("ExtHttp", e)
+        } finally {
+            onTransferEnded(session.network)
+        }
+    }
+
+    /** Inclusive range, or null for full resource. */
+    private fun parseRange(header: String?, total: Long): Pair<Long, Long>? {
+        if (header.isNullOrBlank()) return null
+        // bytes=start-end | bytes=start- | bytes=-suffix
+        if (!header.startsWith("bytes=", ignoreCase = true)) return null
+        val spec = header.substring(6).trim()
+        if (spec.contains(',')) {
+            // Multi-range not supported — serve full body as 200 by ignoring.
+            return null
+        }
+        val dash = spec.indexOf('-')
+        if (dash < 0) return null
+        val startStr = spec.substring(0, dash)
+        val endStr = spec.substring(dash + 1)
+        return when {
+            startStr.isEmpty() && endStr.isNotEmpty() -> {
+                val suffix = endStr.toLongOrNull() ?: return null
+                if (suffix <= 0L) return null
+                val len = suffix.coerceAtMost(total)
+                (total - len) to (total - 1L)
+            }
+            startStr.isNotEmpty() && endStr.isEmpty() -> {
+                val start = startStr.toLongOrNull() ?: return null
+                if (start < 0L || start >= total) return null
+                start to (total - 1L)
+            }
+            startStr.isNotEmpty() && endStr.isNotEmpty() -> {
+                val start = startStr.toLongOrNull() ?: return null
+                val end = endStr.toLongOrNull() ?: return null
+                if (start < 0L || end < start || start >= total) return null
+                start to minOf(end, total - 1L)
+            }
+            else -> null
+        }
+    }
+
+    private fun writeSimple(
+        output: OutputStream,
+        code: Int,
+        message: String,
+        extraHeaders: List<String> = emptyList(),
+    ) {
+        val body = message.toByteArray(Charsets.UTF_8)
+        val sb = StringBuilder()
+        sb.append("HTTP/1.1 $code $message\r\n")
+        sb.append("Content-Type: text/plain; charset=utf-8\r\n")
+        sb.append("Content-Length: ${body.size}\r\n")
+        for (h in extraHeaders) sb.append(h).append("\r\n")
+        sb.append("Connection: close\r\n\r\n")
+        output.write(sb.toString().toByteArray(Charsets.US_ASCII))
+        output.write(body)
+    }
+
+    /** Simple HTML index so clients can discover every registered video/sub under the session. */
+    private fun writeDirectoryListing(
+        output: OutputStream,
+        session: Session,
+        headOnly: Boolean,
+    ) {
+        val names = session.files.values.map { it.displayName }.distinct().sorted()
+        val html = buildString {
+            append("<!DOCTYPE html><html><head><meta charset=\"utf-8\"/>")
+            append("<title>Index of /s/").append(session.id).append("/</title></head><body>")
+            append("<h1>Index of /s/").append(session.id).append("/</h1><hr/><pre>")
+            for (name in names) {
+                val href = Uri.encode(pathKey(name))
+                append("<a href=\"").append(href).append("\">")
+                append(escapeHtml(name)).append("</a>\n")
+            }
+            append("</pre><hr/></body></html>")
+        }
+        val body = html.toByteArray(Charsets.UTF_8)
+        val headers = buildString {
+            append("HTTP/1.1 200 OK\r\n")
+            append("Content-Type: text/html; charset=utf-8\r\n")
+            append("Content-Length: ${body.size}\r\n")
+            append("Connection: close\r\n")
+            append("Cache-Control: no-store\r\n")
+            append("\r\n")
+        }
+        output.write(headers.toByteArray(Charsets.US_ASCII))
+        if (!headOnly) output.write(body)
+    }
+
+    private fun escapeHeader(name: String): String = pathKey(name)
+        .filterNot { it == '\r' || it == '\n' || it == '\u0000' }
+        .replace("\\", "\\\\")
+        .replace("\"", "\\\"")
+
+    private fun escapeHtml(s: String): String = buildString(s.length) {
+        for (c in s) {
+            when (c) {
+                '<' -> append("&lt;")
+                '>' -> append("&gt;")
+                '&' -> append("&amp;")
+                '"' -> append("&quot;")
+                else -> append(c)
+            }
+        }
+    }
+
+    private const val MAX_SESSIONS = 16
+    private const val MAX_CONCURRENT_CONNECTIONS = 8
+    private const val MAX_FILE_NAME_LENGTH = 1024
+    private const val MAX_REQUEST_LINE_LENGTH = 4096
+    private const val MAX_HEADER_LINE_LENGTH = 8192
+    private const val MAX_HEADER_COUNT = 64
+    private const val REQUEST_TIMEOUT_MS = 15_000
+}

--- a/app/src/main/kotlin/com/hippo/ehviewer/provider/StreamDocumentProvider.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/provider/StreamDocumentProvider.kt
@@ -174,18 +174,49 @@ class StreamDocumentProvider : ContentProvider() {
 
         fun authority(): String = "${BuildConfig.APPLICATION_ID}.streamdoc"
 
-        fun uriFor(token: String): Uri = Uri.Builder()
-            .scheme("content")
-            .authority(authority())
-            .appendPath(PATH_SEGMENT)
-            .appendPath(token)
-            .build()
+        /**
+         * Grantable streamdoc URI.
+         *
+         * Shape: `content://…/streamdoc/{token}` or `…/streamdoc/{token}/{displayName}`.
+         *
+         * [token] is the registry key. Optional [displayName] is the last path segment so
+         * external apps show the real file name (many use the URI tail, not
+         * [OpenableColumns.DISPLAY_NAME]). Lookup still uses [token] only — one document
+         * per token. External **video** uses [ExternalHttpStreamServer] for sidecar subs.
+         */
+        fun uriFor(token: String, displayName: String? = null): Uri {
+            val builder = Uri.Builder()
+                .scheme("content")
+                .authority(authority())
+                .appendPath(PATH_SEGMENT)
+                .appendPath(token)
+            val name = displayName?.let { sanitizeDisplayNameForPath(it) }
+            if (!name.isNullOrEmpty()) {
+                builder.appendPath(name)
+            }
+            return builder.build()
+        }
 
         fun tokenOf(uri: Uri): String? {
             val segs = uri.pathSegments
+            // streamdoc/{token} or streamdoc/{token}/{displayName}
             if (segs.size >= 2 && segs[0] == PATH_SEGMENT) return segs[1]
             if (segs.size == 1) return segs[0]
             return null
+        }
+
+        /** Single path segment; keep extension for type sniffing. */
+        fun sanitizeDisplayNameForPath(displayName: String): String {
+            val base = displayName
+                .replace('\\', '/')
+                .substringAfterLast('/')
+                .trim()
+                .ifEmpty { return "file" }
+            return base
+                .replace('/', '_')
+                .replace('\u0000', '_')
+                .take(180)
+                .ifEmpty { "file" }
         }
     }
 }

--- a/app/src/main/kotlin/com/hippo/ehviewer/provider/StreamKeepAlivePolicy.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/provider/StreamKeepAlivePolicy.kt
@@ -57,8 +57,10 @@ object StreamKeepAlivePolicy {
     }
 
     fun onScreenOn(context: Context) {
-        // Re-arm FGS / wake lock if a player still holds a network proxy FD.
-        if (StreamDocumentRegistry.networkOpenCount() > 0) {
+        // Re-arm FGS / wake lock if a player still holds a network proxy FD or HTTP stream.
+        if (StreamDocumentRegistry.networkOpenCount() > 0 ||
+            ExternalHttpStreamServer.networkActivityCount() > 0
+        ) {
             StreamKeepAliveService.start(context)
         }
     }

--- a/app/src/main/kotlin/com/hippo/ehviewer/provider/StreamKeepAliveService.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/provider/StreamKeepAliveService.kt
@@ -50,7 +50,9 @@ class StreamKeepAliveService : Service() {
         // startForegroundService() is asynchronous: a very short-lived external FD may
         // already be released before this callback runs. Preserve the FGS reopen grace,
         // but only keep the CPU awake while a proxy is actually open.
-        if (StreamDocumentRegistry.networkOpenCount() > 0) {
+        if (StreamDocumentRegistry.networkOpenCount() > 0 ||
+            ExternalHttpStreamServer.networkActivityCount() > 0
+        ) {
             acquireWakeLock()
         } else {
             releaseWakeLock()
@@ -61,7 +63,8 @@ class StreamKeepAliveService : Service() {
     }
 
     override fun onTimeout(startId: Int, fgsType: Int) {
-        val stillOpen = StreamDocumentRegistry.networkOpenCount()
+        val stillOpen = StreamDocumentRegistry.networkOpenCount() +
+            ExternalHttpStreamServer.networkActivityCount()
         logcat("StreamKeepAlive") {
             "Foreground service timed out (type=$fgsType) openFds=$stillOpen"
         }

--- a/app/src/main/kotlin/com/hippo/ehviewer/smb/SmbArchiveByteSource.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/smb/SmbArchiveByteSource.kt
@@ -265,7 +265,11 @@ private class KeepOpenSmbFileSource(
                 result.await()
             }
         } catch (e: Throwable) {
-            if (closed.get()) return -1
+            // Prefetch cancel / proxy onRelease interrupt in-flight runBlocking — not a fault.
+            if (closed.get() || e is InterruptedException || e.cause is InterruptedException) {
+                Thread.interrupted() // clear flag so pooled workers stay usable
+                return -1
+            }
             logcat("SmbArchive", e)
             -1
         }

--- a/app/src/main/kotlin/com/hippo/ehviewer/ui/DefaultVideoPlayer.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/ui/DefaultVideoPlayer.kt
@@ -87,7 +87,10 @@ object DefaultVideoPlayer {
     fun videoViewIntent(uri: Uri, mimeType: String): Intent = Intent(Intent.ACTION_VIEW).apply {
         setDataAndType(uri, mimeType)
         addCategory(Intent.CATEGORY_DEFAULT)
-        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        // content/file grants only — http(s) loopback streams need no URI permission.
+        when (uri.scheme?.lowercase()) {
+            "content", "file" -> addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }
         addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
     }
 
@@ -119,6 +122,10 @@ object DefaultVideoPlayer {
             out += query(
                 pm,
                 videoViewIntent(Uri.parse("file:///storage/emulated/0/DCIM/probe.mp4"), mime),
+            )
+            out += query(
+                pm,
+                videoViewIntent(Uri.parse("http://127.0.0.1:1/probe.mp4"), mime),
             )
         }
         return out

--- a/app/src/main/kotlin/com/hippo/ehviewer/ui/OpenFileExternally.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/ui/OpenFileExternally.kt
@@ -6,12 +6,20 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.ParcelFileDescriptor
+import com.ehviewer.core.database.model.SmbSourceEntity
+import com.ehviewer.core.database.model.WebDavSourceEntity
 import com.ehviewer.core.files.openFileDescriptor
 import com.ehviewer.core.i18n.R
 import com.ehviewer.core.util.logcat
 import com.ehviewer.core.util.withIOContext
 import com.ehviewer.core.util.withUIContext
+import com.hippo.ehviewer.Settings
+import com.hippo.ehviewer.library.BrowseEntryRemote
+import com.hippo.ehviewer.library.BrowseSession
+import com.hippo.ehviewer.library.SidecarSubtitles
+import com.hippo.ehviewer.library.isBrowseVideoFileName
 import com.hippo.ehviewer.library.mimeTypeForFileName
+import com.hippo.ehviewer.provider.ExternalHttpStreamServer
 import com.hippo.ehviewer.provider.StreamDocumentProvider
 import com.hippo.ehviewer.provider.StreamDocumentRegistry
 import com.hippo.ehviewer.provider.requestStreamNotificationPermission
@@ -21,17 +29,21 @@ import com.hippo.ehviewer.smb.SmbPasswordStore
 import com.hippo.ehviewer.smb.SmbRepository
 import com.hippo.ehviewer.webdav.WebDavArchiveByteSource
 import com.hippo.ehviewer.webdav.WebDavClient
+import com.hippo.ehviewer.webdav.WebDavGateway
 import com.hippo.ehviewer.webdav.WebDavPasswordStore
 import com.hippo.ehviewer.webdav.WebDavRepository
 import java.io.File
 import java.io.IOException
+import kotlinx.coroutines.runBlocking
 import okio.Path.Companion.toPath
 
 /**
- * Open a non-gallery file (video, regular file, etc.) via [StreamDocumentProvider].
+ * Open a non-gallery file (video, regular file, etc.).
  *
- * - [openLocal]/[openSmb]/[openWebDav] — external app chooser (long-press video).
- * - [playLocal]/[playSmb]/[playWebDav] — in-app Media3 player (tap video).
+ * - **External video** → loopback [ExternalHttpStreamServer]
+ *   (`http://127.0.0.1/…/movie.webm`) so players auto-load sibling subs like SMB explorers.
+ * - **External non-video** → [StreamDocumentProvider] content URI.
+ * - **In-app Media3** ([playLocal]/[playSmb]/[playWebDav]) → streamdoc / StreamDocDataSource.
  */
 object OpenFileExternally {
     suspend fun openLocal(
@@ -40,8 +52,19 @@ object OpenFileExternally {
         displayName: String = File(pathStr).name,
         mimeType: String = mimeTypeForFileName(displayName),
     ) {
-        val token = registerLocal(pathStr, displayName, mimeType)
-        launchRegistered(context, token, displayName, mimeType, networkStream = false, internalPlayer = false)
+        if (DefaultVideoPlayer.isVideoMime(mimeType)) {
+            openLocalVideoHttp(context, pathStr, displayName, mimeType)
+            return
+        }
+        val token = registerLocalStreamdoc(pathStr, displayName, mimeType)
+        launchStreamdoc(
+            context = context,
+            token = token,
+            displayName = displayName,
+            mimeType = mimeType,
+            networkStream = false,
+            internalPlayer = false,
+        )
     }
 
     suspend fun playLocal(
@@ -50,8 +73,8 @@ object OpenFileExternally {
         displayName: String = File(pathStr).name,
         mimeType: String = mimeTypeForFileName(displayName),
     ) {
-        val token = registerLocal(pathStr, displayName, mimeType)
-        launchRegistered(context, token, displayName, mimeType, networkStream = false, internalPlayer = true)
+        val token = registerLocalStreamdoc(pathStr, displayName, mimeType)
+        launchStreamdoc(context, token, displayName, mimeType, networkStream = false, internalPlayer = true)
     }
 
     suspend fun openSmb(
@@ -61,8 +84,19 @@ object OpenFileExternally {
         displayName: String = remoteRelativeFile.substringAfterLast('/').substringAfterLast('\\'),
         mimeType: String = mimeTypeForFileName(displayName),
     ) {
-        val token = registerSmb(sourceId, remoteRelativeFile, displayName, mimeType)
-        launchRegistered(context, token, displayName, mimeType, networkStream = true, internalPlayer = false)
+        if (DefaultVideoPlayer.isVideoMime(mimeType)) {
+            openSmbVideoHttp(context, sourceId, remoteRelativeFile, displayName, mimeType)
+            return
+        }
+        val token = registerSmbStreamdoc(sourceId, remoteRelativeFile, displayName, mimeType)
+        launchStreamdoc(
+            context = context,
+            token = token,
+            displayName = displayName,
+            mimeType = mimeType,
+            networkStream = true,
+            internalPlayer = false,
+        )
     }
 
     suspend fun playSmb(
@@ -72,8 +106,8 @@ object OpenFileExternally {
         displayName: String = remoteRelativeFile.substringAfterLast('/').substringAfterLast('\\'),
         mimeType: String = mimeTypeForFileName(displayName),
     ) {
-        val token = registerSmb(sourceId, remoteRelativeFile, displayName, mimeType)
-        launchRegistered(context, token, displayName, mimeType, networkStream = true, internalPlayer = true)
+        val token = registerSmbStreamdoc(sourceId, remoteRelativeFile, displayName, mimeType)
+        launchStreamdoc(context, token, displayName, mimeType, networkStream = true, internalPlayer = true)
     }
 
     suspend fun openWebDav(
@@ -83,8 +117,19 @@ object OpenFileExternally {
         displayName: String = remoteRelativeFile.substringAfterLast('/').substringAfterLast('\\'),
         mimeType: String = mimeTypeForFileName(displayName),
     ) {
-        val token = registerWebDav(sourceId, remoteRelativeFile, displayName, mimeType)
-        launchRegistered(context, token, displayName, mimeType, networkStream = true, internalPlayer = false)
+        if (DefaultVideoPlayer.isVideoMime(mimeType)) {
+            openWebDavVideoHttp(context, sourceId, remoteRelativeFile, displayName, mimeType)
+            return
+        }
+        val token = registerWebDavStreamdoc(sourceId, remoteRelativeFile, displayName, mimeType)
+        launchStreamdoc(
+            context = context,
+            token = token,
+            displayName = displayName,
+            mimeType = mimeType,
+            networkStream = true,
+            internalPlayer = false,
+        )
     }
 
     suspend fun playWebDav(
@@ -94,11 +139,479 @@ object OpenFileExternally {
         displayName: String = remoteRelativeFile.substringAfterLast('/').substringAfterLast('\\'),
         mimeType: String = mimeTypeForFileName(displayName),
     ) {
-        val token = registerWebDav(sourceId, remoteRelativeFile, displayName, mimeType)
-        launchRegistered(context, token, displayName, mimeType, networkStream = true, internalPlayer = true)
+        val token = registerWebDavStreamdoc(sourceId, remoteRelativeFile, displayName, mimeType)
+        launchStreamdoc(context, token, displayName, mimeType, networkStream = true, internalPlayer = true)
     }
 
-    private suspend fun registerLocal(
+    // region HTTP external video
+
+    /**
+     * Off (default): opened video + matching sidecars only.
+     * On: every video + subtitle file in the same directory (folder playlist).
+     */
+    private fun accessDirEnabled(): Boolean = Settings.externalVideoAccessDir.value
+
+    private fun isHttpExposedMediaName(name: String): Boolean = isBrowseVideoFileName(name) || SidecarSubtitles.isSubtitleFileName(name)
+
+    private fun mediaMimeForName(name: String): String = when {
+        SidecarSubtitles.isSubtitleFileName(name) -> SidecarSubtitles.mimeTypeForSubtitle(name)
+        else -> mimeTypeForFileName(name)
+    }
+
+    private fun canResolveSibling(videoName: String, candidateName: String, accessDir: Boolean): Boolean {
+        if (!ExternalHttpStreamServer.isSafeFileName(candidateName)) return false
+        return if (accessDir) {
+            isHttpExposedMediaName(candidateName)
+        } else {
+            SidecarSubtitles.isSidecarFor(videoName, candidateName)
+        }
+    }
+
+    private suspend fun buildHttpSession(
+        network: Boolean,
+        configure: suspend (ExternalHttpStreamServer.Session) -> Unit,
+    ): ExternalHttpStreamServer.Session {
+        val session = ExternalHttpStreamServer.newSession(network)
+        return try {
+            configure(session)
+            session
+        } catch (e: Throwable) {
+            ExternalHttpStreamServer.removeSession(session.id)
+            throw e
+        }
+    }
+
+    private suspend fun openLocalVideoHttp(
+        context: Context,
+        pathStr: String,
+        displayName: String,
+        mimeType: String,
+    ) {
+        val accessDir = accessDirEnabled()
+        val session = withIOContext {
+            buildHttpSession(network = false) { session ->
+                session.put(localFileEntry(pathStr, displayName, mimeType))
+                session.resolveSibling = resolve@{ name ->
+                    if (!canResolveSibling(displayName, name, accessDir)) return@resolve null
+                    val subPath = siblingPath(pathStr, name) ?: return@resolve null
+                    runCatching {
+                        localFileEntry(subPath, name, mediaMimeForName(name))
+                    }.getOrNull()
+                }
+                val extras = if (accessDir) {
+                    listLocalDirMediaNames(pathStr).filterNot { it.equals(displayName, ignoreCase = true) }
+                } else {
+                    findLocalSidecarNames(pathStr, displayName)
+                }
+                for (name in extras) {
+                    val subPath = siblingPath(pathStr, name) ?: continue
+                    runCatching {
+                        session.put(localFileEntry(subPath, name, mediaMimeForName(name)))
+                    }.onFailure { logcat("OpenFileExternally", it) }
+                }
+            }
+        }
+        val videoUri = ExternalHttpStreamServer.uriFor(session.id, displayName)
+        logcat("OpenFileExternally") {
+            "HTTP local video $videoUri files=${session.files.size} accessDir=$accessDir"
+        }
+        try {
+            launchHttpView(context, videoUri, displayName, mimeType, session, accessDir)
+        } catch (e: Throwable) {
+            ExternalHttpStreamServer.removeSession(session.id)
+            throw e
+        }
+    }
+
+    private suspend fun openSmbVideoHttp(
+        context: Context,
+        sourceId: Long,
+        remoteRelativeFile: String,
+        displayName: String,
+        mimeType: String,
+    ) {
+        requestStreamNotificationPermission(context)
+        val accessDir = accessDirEnabled()
+        val session = withIOContext {
+            val source = SmbRepository.load(sourceId) ?: throw IOException("SMB source missing")
+            val password = SmbPasswordStore.get(sourceId)
+            val sizeBytes = SmbGateway.fileSizeOrNull(source, password, remoteRelativeFile)
+                ?.takeIf { it > 0L }
+                ?: error("empty or unreachable file")
+            val parentDir = parentRelative(remoteRelativeFile)
+            buildHttpSession(network = true) { session ->
+                session.put(
+                    smbFileEntry(source, password, remoteRelativeFile, displayName, mimeType, sizeBytes),
+                )
+                session.resolveSibling = { name ->
+                    // HTTP worker thread — blocking size probe is intentional.
+                    runBlocking {
+                        if (!canResolveSibling(displayName, name, accessDir)) return@runBlocking null
+                        val remote = SmbGateway.joinRelativePath(parentDir, name)
+                        val size = SmbGateway.fileSizeOrNull(source, password, remote)
+                            ?.takeIf { it > 0L }
+                            ?: return@runBlocking null
+                        smbFileEntry(source, password, remote, name, mediaMimeForName(name), size)
+                    }
+                }
+                val extras = if (accessDir) {
+                    listSmbDirMediaNames(sourceId, source, password, parentDir)
+                        .filterNot { it.equals(displayName, ignoreCase = true) }
+                } else {
+                    findSmbSidecarNames(sourceId, source, password, remoteRelativeFile, displayName)
+                }
+                for (name in extras) {
+                    val remote = SmbGateway.joinRelativePath(parentDir, name)
+                    runCatching {
+                        val size = SmbGateway.fileSizeOrNull(source, password, remote)
+                            ?.takeIf { it > 0L }
+                            ?: return@runCatching
+                        session.put(
+                            smbFileEntry(source, password, remote, name, mediaMimeForName(name), size),
+                        )
+                    }.onFailure { logcat("OpenFileExternally", it) }
+                }
+                logcat("OpenFileExternally") {
+                    "HTTP SMB session ${session.id} files=${session.files.size} accessDir=$accessDir"
+                }
+            }
+        }
+        val videoUri = ExternalHttpStreamServer.uriFor(session.id, displayName)
+        try {
+            launchHttpView(context, videoUri, displayName, mimeType, session, accessDir)
+        } catch (e: Throwable) {
+            ExternalHttpStreamServer.removeSession(session.id)
+            throw e
+        }
+    }
+
+    private suspend fun openWebDavVideoHttp(
+        context: Context,
+        sourceId: Long,
+        remoteRelativeFile: String,
+        displayName: String,
+        mimeType: String,
+    ) {
+        requestStreamNotificationPermission(context)
+        val accessDir = accessDirEnabled()
+        val session = withIOContext {
+            val source = WebDavRepository.load(sourceId) ?: throw IOException("WebDAV source missing")
+            val password = WebDavPasswordStore.get(sourceId)
+            val sizeBytes = WebDavClient.fileSizeOrNull(source, password, remoteRelativeFile, sticky = true)
+                ?.takeIf { it > 0L }
+                ?: error("empty or unreachable file")
+            val parentDir = parentRelative(remoteRelativeFile)
+            buildHttpSession(network = true) { session ->
+                session.put(
+                    webDavFileEntry(source, password, remoteRelativeFile, displayName, mimeType, sizeBytes),
+                )
+                session.resolveSibling = { name ->
+                    runBlocking {
+                        if (!canResolveSibling(displayName, name, accessDir)) return@runBlocking null
+                        val remote = WebDavGateway.joinRelative(parentDir, name)
+                        val size = WebDavClient.fileSizeOrNull(source, password, remote, sticky = true)
+                            ?.takeIf { it > 0L }
+                            ?: return@runBlocking null
+                        webDavFileEntry(source, password, remote, name, mediaMimeForName(name), size)
+                    }
+                }
+                val extras = if (accessDir) {
+                    listWebDavDirMediaNames(sourceId, source, password, parentDir)
+                        .filterNot { it.equals(displayName, ignoreCase = true) }
+                } else {
+                    findWebDavSidecarNames(sourceId, source, password, remoteRelativeFile, displayName)
+                }
+                for (name in extras) {
+                    val remote = WebDavGateway.joinRelative(parentDir, name)
+                    runCatching {
+                        val size = WebDavClient.fileSizeOrNull(source, password, remote, sticky = true)
+                            ?.takeIf { it > 0L }
+                            ?: return@runCatching
+                        session.put(
+                            webDavFileEntry(source, password, remote, name, mediaMimeForName(name), size),
+                        )
+                    }.onFailure { logcat("OpenFileExternally", it) }
+                }
+            }
+        }
+        val videoUri = ExternalHttpStreamServer.uriFor(session.id, displayName)
+        try {
+            launchHttpView(context, videoUri, displayName, mimeType, session, accessDir)
+        } catch (e: Throwable) {
+            ExternalHttpStreamServer.removeSession(session.id)
+            throw e
+        }
+    }
+
+    private fun localFileEntry(
+        pathStr: String,
+        displayName: String,
+        mimeType: String,
+    ): ExternalHttpStreamServer.FileEntry {
+        val file = File(pathStr)
+        if (pathStr.startsWith('/') && file.isFile) {
+            val size = file.length().takeIf { it > 0L } ?: error("empty file")
+            return ExternalHttpStreamServer.FileEntry(
+                displayName = displayName,
+                mimeType = mimeType,
+                sizeBytes = size,
+                open = { ExternalHttpStreamServer.LocalFileBody(file) },
+            )
+        }
+        val openPfd: () -> ParcelFileDescriptor = { pathStr.toPath().openFileDescriptor("r") }
+        val size = openPfd().use { it.statSize.takeIf { s -> s > 0L } ?: error("empty file") }
+        return ExternalHttpStreamServer.FileEntry(
+            displayName = displayName,
+            mimeType = mimeType,
+            sizeBytes = size,
+            open = {
+                ExternalHttpStreamServer.PfdBody(openPfd())
+            },
+        )
+    }
+
+    private fun smbFileEntry(
+        source: SmbSourceEntity,
+        password: String,
+        remoteRelativeFile: String,
+        displayName: String,
+        mimeType: String,
+        sizeBytes: Long,
+    ) = ExternalHttpStreamServer.FileEntry(
+        displayName = displayName,
+        mimeType = mimeType,
+        sizeBytes = sizeBytes,
+        open = {
+            ExternalHttpStreamServer.ArchiveBody(
+                SmbArchiveByteSource(
+                    source = source,
+                    password = password,
+                    remoteRelativeFile = remoteRelativeFile,
+                    preferSequential = false,
+                    pipeline = false,
+                    stickySession = true,
+                    knownSize = sizeBytes,
+                    readahead = false,
+                ),
+            )
+        },
+    )
+
+    private fun webDavFileEntry(
+        source: WebDavSourceEntity,
+        password: String,
+        remoteRelativeFile: String,
+        displayName: String,
+        mimeType: String,
+        sizeBytes: Long,
+    ) = ExternalHttpStreamServer.FileEntry(
+        displayName = displayName,
+        mimeType = mimeType,
+        sizeBytes = sizeBytes,
+        open = {
+            ExternalHttpStreamServer.ArchiveBody(
+                WebDavArchiveByteSource(
+                    source = source,
+                    password = password,
+                    remoteRelativeFile = remoteRelativeFile,
+                    preferSequential = false,
+                    pipeline = false,
+                    stickySession = true,
+                    knownSize = sizeBytes,
+                    readahead = false,
+                ),
+            )
+        },
+    )
+
+    private fun findLocalSidecarNames(videoPathStr: String, videoName: String): List<String> {
+        val siblings = findLocalSiblingNames(videoPathStr).ifEmpty {
+            // SAF/Okio-backed paths may support sibling opens without a listable java.io parent.
+            SidecarSubtitles.probeCandidateNames(videoName).filter { name ->
+                val path = siblingPath(videoPathStr, name) ?: return@filter false
+                runCatching { localFileEntry(path, name, mediaMimeForName(name)) }.isSuccess
+            }
+        }
+        return SidecarSubtitles.matchSiblings(
+            videoName,
+            siblings.filter(ExternalHttpStreamServer::isSafeFileName),
+        )
+    }
+
+    /** All browse videos + subtitle files in the local parent directory. */
+    private fun listLocalDirMediaNames(videoPathStr: String): List<String> = findLocalSiblingNames(videoPathStr)
+        .filter { ExternalHttpStreamServer.isSafeFileName(it) && isHttpExposedMediaName(it) }
+        .distinct()
+        .sorted()
+        .take(MAX_DIR_MEDIA_FILES)
+
+    private suspend fun findSmbSidecarNames(
+        sourceId: Long,
+        source: SmbSourceEntity,
+        password: String,
+        remoteRelativeFile: String,
+        videoName: String,
+    ): List<String> {
+        val parentDir = parentRelative(remoteRelativeFile)
+        val names = siblingNamesFromCache(sourceId, parentDir, smb = true)
+            .ifEmpty {
+                SidecarSubtitles.probeCandidateNames(videoName).filter { name ->
+                    val remote = SmbGateway.joinRelativePath(parentDir, name)
+                    SmbGateway.fileSizeOrNull(source, password, remote)?.let { it > 0L } == true
+                }
+            }
+        return SidecarSubtitles.matchSiblings(videoName, names)
+    }
+
+    private suspend fun listSmbDirMediaNames(
+        sourceId: Long,
+        source: SmbSourceEntity,
+        password: String,
+        parentDir: String,
+    ): List<String> {
+        val names = siblingNamesFromCache(sourceId, parentDir, smb = true)
+            .ifEmpty {
+                runCatching {
+                    SmbGateway.listDirectory(source, password, parentDir, useCache = true)
+                        .mapNotNull { e ->
+                            when (e) {
+                                is BrowseEntryRemote.RegularFile -> directChildName(e.fileName)
+                                is BrowseEntryRemote.VideoFile -> directChildName(e.fileName)
+                                else -> null
+                            }
+                        }
+                }.getOrDefault(emptyList())
+            }
+        return names
+            .filter { isHttpExposedMediaName(it) }
+            .distinct()
+            .sorted()
+            .take(MAX_DIR_MEDIA_FILES)
+    }
+
+    private suspend fun findWebDavSidecarNames(
+        sourceId: Long,
+        source: WebDavSourceEntity,
+        password: String,
+        remoteRelativeFile: String,
+        videoName: String,
+    ): List<String> {
+        val parentDir = parentRelative(remoteRelativeFile)
+        val names = siblingNamesFromCache(sourceId, parentDir, smb = false)
+            .ifEmpty {
+                SidecarSubtitles.probeCandidateNames(videoName).filter { name ->
+                    val remote = WebDavGateway.joinRelative(parentDir, name)
+                    WebDavClient.fileSizeOrNull(source, password, remote, sticky = true)
+                        ?.let { it > 0L } == true
+                }
+            }
+        return SidecarSubtitles.matchSiblings(videoName, names)
+    }
+
+    private suspend fun listWebDavDirMediaNames(
+        sourceId: Long,
+        source: WebDavSourceEntity,
+        password: String,
+        parentDir: String,
+    ): List<String> {
+        val names = siblingNamesFromCache(sourceId, parentDir, smb = false)
+            .ifEmpty {
+                runCatching {
+                    WebDavGateway.listDirectory(source, password, parentDir)
+                        .mapNotNull { e ->
+                            when (e) {
+                                is BrowseEntryRemote.RegularFile -> directChildName(e.fileName)
+                                is BrowseEntryRemote.VideoFile -> directChildName(e.fileName)
+                                else -> null
+                            }
+                        }
+                }.getOrDefault(emptyList())
+            }
+        return names
+            .filter { isHttpExposedMediaName(it) }
+            .distinct()
+            .sorted()
+            .take(MAX_DIR_MEDIA_FILES)
+    }
+
+    private suspend fun launchHttpView(
+        context: Context,
+        videoUri: Uri,
+        displayName: String,
+        mimeType: String,
+        session: ExternalHttpStreamServer.Session,
+        accessDir: Boolean,
+    ) {
+        // Sidecars for the opened video (matching stem) — always attach when present.
+        val subUris = session.files.values
+            .filter { SidecarSubtitles.isSidecarFor(displayName, it.displayName) }
+            .sortedWith(compareBy(String.CASE_INSENSITIVE_ORDER) { it.displayName })
+            .map { ExternalHttpStreamServer.uriFor(session.id, it.displayName) }
+        val subNames = subUris.mapNotNull { it.lastPathSegment?.let { s -> Uri.decode(s) } }.toTypedArray()
+        // Full folder playlist when access-dir is on.
+        val videoUris = if (accessDir) {
+            session.files.values
+                .filter { DefaultVideoPlayer.isVideoMime(it.mimeType) }
+                .map { it.displayName }
+                .sorted()
+                .map { ExternalHttpStreamServer.uriFor(session.id, it) }
+        } else {
+            emptyList()
+        }
+        val view = DefaultVideoPlayer.videoViewIntent(videoUri, mimeType).apply {
+            putExtra(Intent.EXTRA_TITLE, displayName)
+            val clip = ClipData.newRawUri(displayName, videoUri)
+            for (i in subUris.indices) {
+                clip.addItem(ClipData.Item(subNames.getOrNull(i), null, subUris[i]))
+            }
+            if (accessDir) {
+                for (u in videoUris) {
+                    if (u != videoUri) clip.addItem(ClipData.Item(u))
+                }
+            }
+            if (clip.itemCount > 1) clipData = clip
+            if (subUris.isNotEmpty()) {
+                attachSubtitleExtras(subUris, subNames)
+            }
+            if (videoUris.size > 1) {
+                attachPlaylistExtras(videoUris, displayName)
+            }
+        }
+        val preferred = DefaultVideoPlayer.preferredComponentOrNull(context)
+        if (preferred != null) {
+            view.component = preferred
+            val launched = withUIContext {
+                try {
+                    context.startActivity(view)
+                    true
+                } catch (e: ActivityNotFoundException) {
+                    logcat("OpenFileExternally", e)
+                    view.component = null
+                    false
+                }
+            }
+            if (launched) return
+        }
+        val title = context.getString(R.string.open_in_other_app)
+        val chooser = Intent.createChooser(view, title).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        withUIContext {
+            try {
+                context.startActivity(chooser)
+            } catch (e: ActivityNotFoundException) {
+                logcat("OpenFileExternally", e)
+                ExternalHttpStreamServer.removeSession(session.id)
+                error(context.getString(R.string.browse_open_failed))
+            }
+        }
+    }
+
+    // endregion
+
+    // region streamdoc (in-app Media3 + non-video external)
+
+    private suspend fun registerLocalStreamdoc(
         pathStr: String,
         displayName: String,
         mimeType: String,
@@ -124,7 +637,7 @@ object OpenFileExternally {
         }
     }
 
-    private suspend fun registerSmb(
+    private suspend fun registerSmbStreamdoc(
         sourceId: Long,
         remoteRelativeFile: String,
         displayName: String,
@@ -143,8 +656,6 @@ object OpenFileExternally {
             displayName = displayName,
             mimeType = mimeType,
             sizeBytes = sizeBytes,
-            // Each SmbArchiveByteSource(stickySession=true) owns an independent TCP session,
-            // so video dual-lane prefetch may open a second demand-free lane safely.
             parallelPrefetch = true,
             openSource = {
                 SmbArchiveByteSource(
@@ -155,14 +666,13 @@ object OpenFileExternally {
                     pipeline = false,
                     stickySession = true,
                     knownSize = sizeBytes,
-                    // Windowing/prefetch owned by VideoDirectLinkByteSource for video.
                     readahead = false,
                 )
             },
         )
     }
 
-    private suspend fun registerWebDav(
+    private suspend fun registerWebDavStreamdoc(
         sourceId: Long,
         remoteRelativeFile: String,
         displayName: String,
@@ -200,7 +710,64 @@ object OpenFileExternally {
         )
     }
 
-    private suspend fun launchRegistered(
+    private fun findLocalSiblingNames(videoPathStr: String): List<String> {
+        if (videoPathStr.startsWith('/')) {
+            val parent = File(videoPathStr).parentFile ?: return emptyList()
+            return parent.list()?.toList().orEmpty()
+        }
+        return runCatching {
+            val path = videoPathStr.toPath()
+            val parent = path.parent ?: return@runCatching emptyList()
+            val parentFile = File(parent.toString())
+            if (parentFile.isDirectory) {
+                parentFile.list()?.toList().orEmpty()
+            } else {
+                emptyList()
+            }
+        }.getOrDefault(emptyList())
+    }
+
+    private fun siblingPath(videoPathStr: String, siblingName: String): String? {
+        if (videoPathStr.startsWith('/')) {
+            val parent = File(videoPathStr).parentFile ?: return null
+            return File(parent, siblingName).path
+        }
+        return runCatching {
+            val path = videoPathStr.toPath()
+            val parent = path.parent ?: return@runCatching null
+            (parent / siblingName).toString()
+        }.getOrNull()
+    }
+
+    private fun siblingNamesFromCache(sourceId: Long, parentDir: String, smb: Boolean): List<String> {
+        val listing = if (smb) {
+            BrowseSession.getSmbListing(sourceId, parentDir)
+        } else {
+            BrowseSession.getWebDavListing(sourceId, parentDir)
+        } ?: return emptyList()
+        return listing.mapNotNull { entry ->
+            when (entry) {
+                is BrowseEntryRemote.RegularFile -> directChildName(entry.fileName)
+                is BrowseEntryRemote.VideoFile -> directChildName(entry.fileName)
+                else -> null
+            }
+        }
+    }
+
+    /** Reject promoted descendants; HTTP folder access is limited to the video's directory. */
+    private fun directChildName(relativeName: String): String? {
+        val normalized = relativeName.replace('\\', '/')
+        if ('/' in normalized) return null
+        return normalized.takeIf(ExternalHttpStreamServer::isSafeFileName)
+    }
+
+    private fun parentRelative(remoteRelativeFile: String): String {
+        val normalized = remoteRelativeFile.replace('\\', '/').trim('/')
+        val slash = normalized.lastIndexOf('/')
+        return if (slash <= 0) "" else normalized.substring(0, slash)
+    }
+
+    private suspend fun launchStreamdoc(
         context: Context,
         token: String,
         displayName: String,
@@ -208,15 +775,38 @@ object OpenFileExternally {
         networkStream: Boolean,
         internalPlayer: Boolean,
     ) {
-        val uri = StreamDocumentProvider.uriFor(token)
+        val uri = StreamDocumentProvider.uriFor(token, displayName)
         try {
-            // External open still needs the streamdoc FGS/proxy path for SMB/WebDAV.
-            // In-app Media3 uses StreamDocDataSource (no FUSE) — skip notification prompt.
             if (networkStream && !internalPlayer) requestStreamNotificationPermission(context)
             if (internalPlayer) {
-                launchInternalPlayer(context, uri, displayName, mimeType, token)
+                val intent = VideoPlayerActivity.intent(
+                    context = context,
+                    uri = uri,
+                    title = displayName,
+                    mimeType = mimeType,
+                    streamToken = token,
+                ).apply {
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                }
+                withUIContext { context.startActivity(intent) }
             } else {
-                launchView(context, uri, displayName, mimeType)
+                val view = DefaultVideoPlayer.videoViewIntent(uri, mimeType).apply {
+                    putExtra(Intent.EXTRA_TITLE, displayName)
+                    clipData = ClipData.newRawUri(displayName, uri)
+                }
+                val title = context.getString(R.string.open_in_other_app)
+                val chooser = Intent.createChooser(view, title).apply {
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                }
+                withUIContext {
+                    try {
+                        context.startActivity(chooser)
+                    } catch (e: ActivityNotFoundException) {
+                        logcat("OpenFileExternally", e)
+                        error(context.getString(R.string.browse_open_failed))
+                    }
+                }
             }
         } catch (e: Throwable) {
             StreamDocumentRegistry.remove(token)
@@ -224,66 +814,32 @@ object OpenFileExternally {
         }
     }
 
-    private suspend fun launchInternalPlayer(
-        context: Context,
-        uri: Uri,
-        displayName: String,
-        mimeType: String,
-        token: String,
-    ) {
-        val intent = VideoPlayerActivity.intent(
-            context = context,
-            uri = uri,
-            title = displayName,
-            mimeType = mimeType,
-            streamToken = token,
-        ).apply {
-            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    // endregion
+
+    private fun Intent.attachSubtitleExtras(subUris: List<Uri>, subNames: Array<String>) {
+        putExtra("subs", subUris.toTypedArray())
+        if (subNames.size == subUris.size) {
+            putExtra("subs.name", subNames)
         }
-        withUIContext {
-            context.startActivity(intent)
-        }
+        putExtra("subtitles_location", subUris.first().toString())
+        putExtra("subtitle", subUris.first().toString())
+        putExtra("subtitle_uri", subUris.first())
     }
 
-    private suspend fun launchView(
-        context: Context,
-        uri: Uri,
-        displayName: String,
-        mimeType: String,
-    ) {
-        val view = DefaultVideoPlayer.videoViewIntent(uri, mimeType).apply {
-            clipData = ClipData.newRawUri(displayName, uri)
+    /**
+     * Best-effort playlist extras for players that support multi-file open
+     * (folder access-dir mode). Intent [data] remains the opened video.
+     */
+    private fun Intent.attachPlaylistExtras(videoUris: List<Uri>, currentName: String) {
+        putExtra("video_list", videoUris.toTypedArray())
+        putParcelableArrayListExtra(Intent.EXTRA_STREAM, ArrayList(videoUris))
+        // Some players want the index of the current item in the list.
+        val idx = videoUris.indexOfFirst {
+            Uri.decode(it.lastPathSegment.orEmpty()) == currentName
         }
-        // Preferred external player only for video MIME; other files keep the chooser.
-        if (DefaultVideoPlayer.isVideoMime(mimeType)) {
-            val preferred = DefaultVideoPlayer.preferredComponentOrNull(context)
-            if (preferred != null) {
-                view.component = preferred
-                val launched = withUIContext {
-                    try {
-                        context.startActivity(view)
-                        true
-                    } catch (e: ActivityNotFoundException) {
-                        logcat("OpenFileExternally", e)
-                        view.component = null
-                        false
-                    }
-                }
-                if (launched) return
-            }
-        }
-        val title = context.getString(R.string.open_in_other_app)
-        val chooser = Intent.createChooser(view, title).apply {
-            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-        }
-        withUIContext {
-            try {
-                context.startActivity(chooser)
-            } catch (e: ActivityNotFoundException) {
-                logcat("OpenFileExternally", e)
-                error(context.getString(R.string.browse_open_failed))
-            }
-        }
+        if (idx >= 0) putExtra("playlist_index", idx)
     }
+
+    /** Cap directory publish so open-with stays snappy on huge shares. */
+    private const val MAX_DIR_MEDIA_FILES = 80
 }

--- a/app/src/main/kotlin/com/hippo/ehviewer/ui/OpenPdfExternally.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/ui/OpenPdfExternally.kt
@@ -83,7 +83,7 @@ object OpenPdfExternally {
         displayName: String,
         networkStream: Boolean = false,
     ) {
-        val uri = StreamDocumentProvider.uriFor(token)
+        val uri = StreamDocumentProvider.uriFor(token, displayName)
         try {
             if (networkStream) requestStreamNotificationPermission(context)
             launchView(context, uri, displayName)
@@ -179,6 +179,7 @@ object OpenPdfExternally {
             addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
             // Chooser may run in a new task when not started from an Activity base.
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            putExtra(Intent.EXTRA_TITLE, displayName)
             // Without ClipData, FLAG_GRANT_READ_URI_PERMISSION is often ignored for the
             // app the user picks in createChooser (streamdoc grant would not reach Drive).
             clipData = ClipData.newRawUri(displayName, uri)

--- a/app/src/main/kotlin/com/hippo/ehviewer/ui/settings/EhScreen.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/ui/settings/EhScreen.kt
@@ -153,6 +153,11 @@ fun AnimatedVisibilityScope.EhScreen(navigator: DestinationsNavigator) = Screen(
                     }
                 }
             }
+            SwitchPreference(
+                title = stringResource(id = R.string.settings_external_video_access_dir),
+                summary = stringResource(id = R.string.settings_external_video_access_dir_summary),
+                state = Settings.externalVideoAccessDir.asMutableState(),
+            )
             val showSmallGalleries = Settings.browseShowSmallGalleries.asMutableState()
             SwitchPreference(
                 title = stringResource(id = R.string.settings_browse_menu_small_galleries),

--- a/core/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/core/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -72,6 +72,8 @@
     <string name="settings_default_video_player">Default video player</string>
     <string name="settings_default_video_player_always_ask">Always ask</string>
     <string name="settings_default_video_player_none">No video apps found</string>
+    <string name="settings_external_video_access_dir">Open folder with video player</string>
+    <string name="settings_external_video_access_dir_summary">Off: open only this video and matching subtitles. On: expose the whole folder (all videos and subtitles) so the player can use playlist / next-prev.</string>
     <string name="browse_menu_page_count">Page count</string>
     <string name="browse_menu_reading_progress">Reading progress</string>
     <string name="browse_menu_small_galleries">Small galleries</string>

--- a/core/i18n/src/commonMain/moko-resources/zh-rCN/strings.xml
+++ b/core/i18n/src/commonMain/moko-resources/zh-rCN/strings.xml
@@ -68,6 +68,8 @@
     <string name="settings_default_video_player">默认视频播放器</string>
     <string name="settings_default_video_player_always_ask">每次询问</string>
     <string name="settings_default_video_player_none">未找到视频应用</string>
+    <string name="settings_external_video_access_dir">用视频播放器打开文件夹</string>
+    <string name="settings_external_video_access_dir_summary">关闭：仅打开当前视频及匹配字幕。开启：向播放器暴露整个文件夹（全部视频与字幕，便于播放列表/上下集）。</string>
     <string name="browse_menu_page_count">页数</string>
     <string name="browse_menu_reading_progress">阅读进度</string>
     <string name="browse_menu_small_galleries">小图库</string>

--- a/core/i18n/src/commonMain/moko-resources/zh-rTW/strings.xml
+++ b/core/i18n/src/commonMain/moko-resources/zh-rTW/strings.xml
@@ -72,6 +72,8 @@
     <string name="settings_default_video_player">預設影片播放器</string>
     <string name="settings_default_video_player_always_ask">每次詢問</string>
     <string name="settings_default_video_player_none">找不到影片應用</string>
+    <string name="settings_external_video_access_dir">用影片播放器開啟資料夾</string>
+    <string name="settings_external_video_access_dir_summary">關閉：僅開啟目前影片及匹配字幕。開啟：向播放器暴露整個資料夾（全部影片與字幕，便於播放清單／上下集）。</string>
     <string name="browse_menu_page_count">頁數</string>
     <string name="browse_menu_reading_progress">閱讀進度</string>
     <string name="browse_menu_small_galleries">小圖庫</string>


### PR DESCRIPTION
## What changed

- Serve externally opened local, SMB, and WebDAV videos through a device-local HTTP Range server.
- Preserve real filenames and publish matching sidecar subtitles so external players can discover or receive them.
- Add an opt-in setting to expose same-directory videos and subtitles for playlist / next-previous navigation.
- Keep SMB/WebDAV HTTP playback alive with the existing foreground-service policy.
- Keep in-app Media3 playback and external non-video documents on the existing stream-document path.

## Release hardening

- Bind only to `127.0.0.1` and use unguessable per-open session IDs.
- Restrict on-demand sibling resolution to safe basenames in the video's current directory.
- In default mode, resolve only subtitles matching the opened video's stem.
- Exclude promoted subdirectory entries from folder exposure.
- Bound request headers and concurrent connections, reject malformed/unsatisfiable ranges, and clean up failed sessions.
- Restore subtitle probing for local SAF/Okio paths whose parent cannot be listed.

## Why

The previous `content://` handoff let external players read the video but did not give them sibling-style URLs, so they could not automatically discover sidecar subtitles. The loopback HTTP layout provides stable sibling filenames while retaining seekable Range reads.

## Validation

- `git diff --check`
- Verified branch is one commit ahead of current `main` with no merge-base drift.
- GitHub Actions Spotless and release build are expected on this draft PR.
- Local Gradle execution was unavailable because the isolated workspace could not download Gradle 9.5.1 and only had Java 17 while the project requires Java 26.