### PR TITLE
Harden external HTTP video streaming lifecycle

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -188,7 +188,7 @@
             android:authorities="${applicationId}.streamdoc"
             android:exported="false"
             android:grantUriPermissions="true" />
-        <!-- Keeps network streamdoc proxy I/O alive while another app holds its FD. -->
+        <!-- Keeps network streamdoc and loopback HTTP I/O alive for external apps. -->
         <service
             android:name="com.hippo.ehviewer.provider.StreamKeepAliveService"
             android:exported="false"

--- a/app/src/main/kotlin/com/hippo/ehviewer/Settings.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/Settings.kt
@@ -110,6 +110,14 @@ object Settings : DataStorePreferences(null) {
     val externalVideoAccessDir = boolPref("external_video_access_dir", false)
 
     /**
+     * When true (and [externalVideoAccessDir] is on), external open hands the folder to the
+     * player as a loopback **m3u8** playlist of every video in the directory (current file
+     * first). When false, the opened video URI is the intent data and multi-file extras are
+     * attached best-effort. Settings → General (nested under folder access).
+     */
+    val externalVideoPassFolderPlaylist = boolPref("external_video_pass_folder_playlist", false)
+
+    /**
      * When true, folder-view shows folder galleries below [browseSmallGalleryMinPages].
      * Default false: UI hides those rows (scanner listing is unchanged).
      */

--- a/app/src/main/kotlin/com/hippo/ehviewer/library/HistoryThumbKey.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/library/HistoryThumbKey.kt
@@ -15,7 +15,8 @@ import okio.Path
  *   `dav-arch:…` → [ArchiveCoverCache] first-page JPEG (`archive_thumb/`, same key as
  *   browse `smb:` / `webdav:` stream covers).
  *
- * Dir-only browse history (`*_browse` tokens) does not store thumbs.
+ * Dir-only browse history (`*_browse` tokens) uses the **folder** thumb key
+ * (local path / `smb-thumb:` / `dav-thumb:`), same as folder favourites — not archive keys.
  */
 object HistoryThumbKey {
     private const val SMB_PREFIX = "smb-thumb:"

--- a/app/src/main/kotlin/com/hippo/ehviewer/library/LocalHistory.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/library/LocalHistory.kt
@@ -167,21 +167,26 @@ object LocalHistory {
     }
 
     /**
-     * Browse **directory listing** only (PDF external / explicit folder path).
+     * Browse **directory listing** only (PDF / video / external document open).
      * Folder galleries use [recordLocalFolderGallery] instead — History opens the reader.
+     *
+     * [thumbKey]: folder-thumb cache key (local absolute cover path). Null keeps any
+     * previously stored key so re-records do not wipe covers.
      */
     suspend fun recordLocalBrowseFolder(
         rootId: Long,
         relativePath: String,
         title: String,
+        thumbKey: String? = null,
         pages: Int = 0,
     ) {
         val rel = normalizeRel(relativePath)
+        val gid = stableGalleryId(rootId, "browse:$rel")
         val info = BaseGalleryInfo(
-            gid = stableGalleryId(rootId, "browse:$rel"),
+            gid = gid,
             token = LOCAL_BROWSE_TOKEN,
             title = title.ifBlank { humanizePathName(rel.substringAfterLast('/').ifEmpty { "Folder" }) },
-            thumbKey = null,
+            thumbKey = resolveThumbKey(gid, thumbKey),
             category = 0,
             uploader = encodeLocalBrowse(rootId, rel),
             rating = -1f,
@@ -191,18 +196,24 @@ object LocalHistory {
         EhDB.putHistoryInfo(info)
     }
 
+    /**
+     * SMB browse directory. [thumbKey] = [HistoryThumbKey.smb] for the folder cover
+     * (same encoding as folder-gallery / favourite thumbs).
+     */
     suspend fun recordSmbBrowseFolder(
         sourceId: Long,
         relativePath: String,
         title: String,
+        thumbKey: String? = null,
         pages: Int = 0,
     ) {
         val rel = normalizeRel(relativePath)
+        val gid = stableGalleryId(sourceId, "smb-browse:$rel")
         val info = BaseGalleryInfo(
-            gid = stableGalleryId(sourceId, "smb-browse:$rel"),
+            gid = gid,
             token = SMB_BROWSE_TOKEN,
             title = title.ifBlank { rel.substringAfterLast('/').ifEmpty { "Share" } },
-            thumbKey = null,
+            thumbKey = resolveThumbKey(gid, thumbKey),
             category = 2,
             uploader = encodeSmbBrowse(sourceId, rel),
             rating = -1f,
@@ -212,18 +223,23 @@ object LocalHistory {
         EhDB.putHistoryInfo(info)
     }
 
+    /**
+     * WebDAV browse directory. [thumbKey] = [HistoryThumbKey.webdav] for the folder cover.
+     */
     suspend fun recordWebDavBrowseFolder(
         sourceId: Long,
         relativePath: String,
         title: String,
+        thumbKey: String? = null,
         pages: Int = 0,
     ) {
         val rel = normalizeRel(relativePath)
+        val gid = stableGalleryId(sourceId, "webdav-browse:$rel")
         val info = BaseGalleryInfo(
-            gid = stableGalleryId(sourceId, "webdav-browse:$rel"),
+            gid = gid,
             token = WEBDAV_BROWSE_TOKEN,
             title = title.ifBlank { rel.substringAfterLast('/').ifEmpty { "WebDAV" } },
-            thumbKey = null,
+            thumbKey = resolveThumbKey(gid, thumbKey),
             category = 3,
             uploader = encodeWebDavBrowse(sourceId, rel),
             rating = -1f,
@@ -231,6 +247,99 @@ object LocalHistory {
             favoriteSlot = NOT_FAVORITED,
         )
         EhDB.putHistoryInfo(info)
+    }
+
+    /**
+     * Best-effort folder-thumb key for a **browse-dir** history row (no network).
+     * Order: dual-gallery cover of the listed dir → parent listing [BrowseEntry.Directory]
+     * cover → favourite thumb for this path.
+     */
+    fun localBrowseFolderThumbKey(
+        rootId: Long,
+        relativePath: String,
+        currentPath: String,
+        entries: List<BrowseEntry>,
+        parentPath: String? = null,
+    ): String? {
+        entries.asSequence()
+            .filterIsInstance<BrowseEntry.FolderGallery>()
+            .firstOrNull { it.path.toString() == currentPath }
+            ?.coverPath?.toString()?.takeIf { it.isNotBlank() }
+            ?.let { return it }
+
+        val rel = normalizeRel(relativePath)
+        if (rel.isNotEmpty() && !parentPath.isNullOrEmpty()) {
+            val dirName = rel.substringAfterLast('/')
+            BrowseSession.getLocalListing(parentPath)
+                ?.asSequence()
+                ?.filterIsInstance<BrowseEntry.Directory>()
+                ?.firstOrNull { it.path.toString() == currentPath || it.name == dirName }
+                ?.coverPath?.toString()?.takeIf { it.isNotBlank() }
+                ?.let { return it }
+        }
+
+        return BrowseFavorites.thumbKeyFor(BrowseFavorites.localFolderKey(rootId, rel))
+    }
+
+    /**
+     * SMB folder-thumb key for browse-dir history. Dual-gallery cover of [relativeDir],
+     * else Directory cover from parent listing, else favourite.
+     */
+    fun smbBrowseFolderThumbKey(
+        sourceId: Long,
+        relativeDir: String,
+        entries: List<BrowseEntryRemote>,
+    ): String? {
+        val rel = normalizeRel(relativeDir)
+        entries.asSequence()
+            .filterIsInstance<BrowseEntryRemote.FolderGallery>()
+            .firstOrNull { it.relativeName.isEmpty() }
+            ?.coverFileName?.takeIf { it.isNotBlank() }
+            ?.let { fileName -> return HistoryThumbKey.smb(sourceId, joinRemote(rel, fileName)) }
+
+        if (rel.isNotEmpty()) {
+            val parentRel = parentRelativeOfFile(rel)
+            BrowseSession.getSmbListing(sourceId, parentRel)
+                ?.asSequence()
+                ?.filterIsInstance<BrowseEntryRemote.Directory>()
+                ?.firstOrNull { joinRemote(parentRel, it.relativeName) == rel }
+                ?.coverFileName?.takeIf { it.isNotBlank() }
+                ?.let { fileName -> return HistoryThumbKey.smb(sourceId, joinRemote(rel, fileName)) }
+        }
+
+        return BrowseFavorites.thumbKeyFor(BrowseFavorites.smbFolderKey(sourceId, rel))
+    }
+
+    /** WebDAV folder-thumb key for browse-dir history (mirrors [smbBrowseFolderThumbKey]). */
+    fun webDavBrowseFolderThumbKey(
+        sourceId: Long,
+        relativeDir: String,
+        entries: List<BrowseEntryRemote>,
+    ): String? {
+        val rel = normalizeRel(relativeDir)
+        entries.asSequence()
+            .filterIsInstance<BrowseEntryRemote.FolderGallery>()
+            .firstOrNull { it.relativeName.isEmpty() }
+            ?.coverFileName?.takeIf { it.isNotBlank() }
+            ?.let { fileName -> return HistoryThumbKey.webdav(sourceId, joinRemote(rel, fileName)) }
+
+        if (rel.isNotEmpty()) {
+            val parentRel = parentRelativeOfFile(rel)
+            BrowseSession.getWebDavListing(sourceId, parentRel)
+                ?.asSequence()
+                ?.filterIsInstance<BrowseEntryRemote.Directory>()
+                ?.firstOrNull { joinRemote(parentRel, it.relativeName) == rel }
+                ?.coverFileName?.takeIf { it.isNotBlank() }
+                ?.let { fileName -> return HistoryThumbKey.webdav(sourceId, joinRemote(rel, fileName)) }
+        }
+
+        return BrowseFavorites.thumbKeyFor(BrowseFavorites.webDavFolderKey(sourceId, rel))
+    }
+
+    private fun joinRemote(dir: String, file: String): String {
+        val d = dir.trim('/')
+        val f = file.replace('\\', '/').trimStart('/')
+        return if (d.isEmpty()) f else "$d/$f"
     }
 
     /**
@@ -335,11 +444,12 @@ object LocalHistory {
         LocalLibrary.loadGalleryByContentPath(path)?.let { return it.toBaseGalleryInfo() }
         val name = title?.ifBlank { null }
             ?: path.trimEnd('/').substringAfterLast('/').ifEmpty { "Archive" }
+        val cover = coverPath?.takeIf { it.isNotBlank() } ?: cachedLocalArchiveCover(path)
         return BaseGalleryInfo(
             gid = stableGalleryId(0L, "local-archive:$path"),
             token = LOCAL_ARCHIVE_TOKEN,
             title = name,
-            thumbKey = coverPath,
+            thumbKey = cover,
             category = 1,
             uploader = path,
             rating = -1f,
@@ -361,7 +471,15 @@ object LocalHistory {
             return
         }
         val info = galleryInfoForLocalArchive(path, title, coverPath, pages)
+        // Prefer supplied / cached cover; keep prior thumbKey when still blank.
+        info.thumbKey = resolveThumbKey(info.gid, info.thumbKey)
         EhDB.putHistoryInfo(info)
+    }
+
+    /** Disk-hit only: [ArchiveCoverCache] first-page JPEG for a local archive path. */
+    private fun cachedLocalArchiveCover(path: String): String? {
+        val dest = ArchiveCoverCache.resolveCoverDest(path)
+        return if (ArchiveCoverCache.isCachedOnDisk(dest)) dest.toString() else null
     }
 
     /**

--- a/app/src/main/kotlin/com/hippo/ehviewer/provider/ExternalHttpStreamServer.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/provider/ExternalHttpStreamServer.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import splitties.init.appCtx
 
@@ -148,9 +149,19 @@ object ExternalHttpStreamServer {
         private val bodyCache = HashMap<String, CachedBody>()
         /** Basename of the single warm dual-sticky video body (at most one per session). */
         @Volatile private var activeBodyKey: String? = null
+        /** Live client sockets serving this session (abort on teardown / switch). */
+        private val liveSockets = ConcurrentHashMap.newKeySet<Socket>()
 
         fun touch() {
             lastAccessMs = SystemClock.elapsedRealtime()
+        }
+
+        fun attachSocket(socket: Socket) {
+            liveSockets.add(socket)
+        }
+
+        fun detachSocket(socket: Socket) {
+            liveSockets.remove(socket)
         }
 
         fun put(entry: FileEntry) {
@@ -229,6 +240,11 @@ object ExternalHttpStreamServer {
         }
 
         fun closeBodies() {
+            // Unblock stalled body writes so activeTransfers can drop and FGS can stop.
+            for (socket in liveSockets.toList()) {
+                runCatching { socket.close() }
+            }
+            liveSockets.clear()
             synchronized(bodyLock) {
                 for ((_, cached) in bodyCache) {
                     runCatching { cached.body.close() }
@@ -285,14 +301,15 @@ object ExternalHttpStreamServer {
     private val activeTransfers = AtomicInteger(0)
     private val keepAliveLock = Any()
     private var stopKeepAliveJob: Job? = null
+    private var warmBodyJob: Job? = null
     private var pruneJob: Job? = null
 
     /**
      * Live **network HTTP body transfers** only (for FGS wake lock / screen-on).
      *
-     * Idle sessions stay registered for resume ([StreamKeepAlivePolicy.tokenMaxAgeMs],
-     * ~20 min limited) but do **not** count as activity — same idea as streamdoc tokens
-     * that outlive their proxy FDs. No activity → no wake lock / short FGS grace only.
+     * Counts in-flight GET body streams (not warm sticky bodies, not idle sessions).
+     * Player pause/stop that leaves a half-open Range is aborted by [BODY_STALL_MS] so this
+     * counter cannot stick forever.
      */
     fun networkActivityCount(): Int = activeTransfers.get()
 
@@ -399,6 +416,8 @@ object ExternalHttpStreamServer {
         synchronized(keepAliveLock) {
             stopKeepAliveJob?.cancel()
             stopKeepAliveJob = null
+            warmBodyJob?.cancel()
+            warmBodyJob = null
             StreamKeepAliveService.start(context)
         }
         maybeStopKeepAliveLater()
@@ -406,27 +425,35 @@ object ExternalHttpStreamServer {
 
     private fun onTransferStarted(network: Boolean, context: Context = appCtx) {
         if (!network) return
-        activeTransfers.incrementAndGet()
+        val n = activeTransfers.incrementAndGet()
+        logcat("ExtHttp") { "transfer start active=$n" }
         synchronized(keepAliveLock) {
             stopKeepAliveJob?.cancel()
             stopKeepAliveJob = null
+            warmBodyJob?.cancel()
+            warmBodyJob = null
             StreamKeepAliveService.start(context)
         }
     }
 
     private fun onTransferEnded(network: Boolean) {
         if (!network) return
-        activeTransfers.updateAndGet { (it - 1).coerceAtLeast(0) }
-        if (activeTransfers.get() == 0) {
+        val n = activeTransfers.updateAndGet { (it - 1).coerceAtLeast(0) }
+        logcat("ExtHttp") { "transfer end active=$n" }
+        if (n == 0) {
             // Drop CPU wake immediately; FGS stops after short grace (sessions still valid).
             StreamKeepAliveService.onNetworkIdle()
             maybeStopKeepAliveLater()
+            maybeReleaseWarmBodiesLater()
         }
     }
 
     /**
      * After last network transfer (or session open with no traffic), stop FGS once the
      * reopen grace elapses — **even if sessions remain** for later resume.
+     *
+     * Always releases warm HTTP sticky bodies when FGS stops (HTTP has no long-lived FD;
+     * next Range reopens dual sticky). Matches player stop / long pause / app switch.
      */
     private fun maybeStopKeepAliveLater(context: Context = appCtx) {
         synchronized(keepAliveLock) {
@@ -438,21 +465,48 @@ object ExternalHttpStreamServer {
                         StreamDocumentRegistry.networkOpenCount() == 0
                     ) {
                         StreamKeepAliveService.stop(context)
-                        // Limited mode: tear down sticky TCP while sessions stay in memory.
-                        // Next HTTP open rebuilds sticky SMB/WebDAV (reconnect-as-needed).
-                        if (StreamKeepAlivePolicy.dropNetworkOnScreenOff() &&
-                            sessions.values.any { it.network }
-                        ) {
-                            // Close warm HTTP bodies so sticky handles drop with the pool.
-                            for (session in sessions.values) {
-                                if (session.network) session.closeBodies()
-                            }
-                            StreamKeepAlivePolicy.dropStickyNetwork("http_idle")
-                        }
+                        releaseNetworkHttpBodies("fgs_idle")
                         stopKeepAliveJob = null
+                        warmBodyJob = null
                     }
                 }
             }
+        }
+    }
+
+    /**
+     * Drop dual-sticky video bodies sooner than full FGS grace when the player is not
+     * pulling data (switch file / stop / long buffer). FGS may still run until grace ends.
+     */
+    private fun maybeReleaseWarmBodiesLater() {
+        synchronized(keepAliveLock) {
+            warmBodyJob?.cancel()
+            warmBodyJob = scope.launch {
+                delay(WARM_BODY_IDLE_MS)
+                synchronized(keepAliveLock) {
+                    if (activeTransfers.get() == 0) {
+                        releaseNetworkHttpBodies("transfer_idle")
+                    }
+                    warmBodyJob = null
+                }
+            }
+        }
+    }
+
+    private fun releaseNetworkHttpBodies(reason: String) {
+        var closed = 0
+        for (session in sessions.values) {
+            if (session.network) {
+                session.closeBodies()
+                closed++
+            }
+        }
+        if (closed > 0) {
+            logcat("ExtHttp") { "released warm network bodies ($reason) sessions=$closed" }
+        }
+        // Limited mode also force-drops any leftover sticky sockets (Fuse + HTTP).
+        if (StreamKeepAlivePolicy.dropNetworkOnScreenOff()) {
+            StreamKeepAlivePolicy.dropStickyNetwork(reason)
         }
     }
 
@@ -501,6 +555,7 @@ object ExternalHttpStreamServer {
     // endregion
 
     private fun handleClient(socket: Socket) {
+        var boundSession: Session? = null
         try {
             val input = BufferedInputStream(socket.getInputStream())
             val output = BufferedOutputStream(socket.getOutputStream())
@@ -515,17 +570,27 @@ object ExternalHttpStreamServer {
                     break
                 } ?: break
                 requests++
-                // Long movie Range replies must not die on SO_TIMEOUT mid-body.
+                // Header idle uses SO_TIMEOUT; body uses a progress watchdog (writes block
+                // without SO_TIMEOUT when the player pauses with a full TCP window).
                 socket.soTimeout = 0
                 val moreAllowed = requests < MAX_REQUESTS_PER_CONNECTION
                 val clientWantsKeepAlive = wantsKeepAlive(request) && moreAllowed
                 val keepAlive = when (request.method) {
-                    "GET", "HEAD" -> serve(
-                        request,
-                        output,
-                        headOnly = request.method == "HEAD",
-                        preferKeepAlive = clientWantsKeepAlive,
-                    )
+                    "GET", "HEAD" -> {
+                        val session = sessionForPath(request.path)
+                        if (session != null && session !== boundSession) {
+                            boundSession?.detachSocket(socket)
+                            session.attachSocket(socket)
+                            boundSession = session
+                        }
+                        serve(
+                            request,
+                            output,
+                            socket,
+                            headOnly = request.method == "HEAD",
+                            preferKeepAlive = clientWantsKeepAlive,
+                        )
+                    }
                     else -> {
                         writeSimple(output, 405, "Method Not Allowed", keepAlive = false)
                         false
@@ -537,8 +602,18 @@ object ExternalHttpStreamServer {
         } catch (e: Throwable) {
             if (e !is IOException) logcat("ExtHttp", e)
         } finally {
+            boundSession?.detachSocket(socket)
             runCatching { socket.close() }
         }
+    }
+
+    private fun sessionForPath(path: String): Session? {
+        val rawPath = path.substringBefore('?')
+        val segs = runCatching {
+            rawPath.trim('/').split('/').map { URLDecoder.decode(it, Charsets.UTF_8) }
+        }.getOrNull() ?: return null
+        if (segs.size < 2 || segs[0] != "s") return null
+        return sessions[segs[1]]
     }
 
     private data class HttpRequest(
@@ -599,6 +674,7 @@ object ExternalHttpStreamServer {
     private fun serve(
         request: HttpRequest,
         output: OutputStream,
+        socket: Socket,
         headOnly: Boolean,
         preferKeepAlive: Boolean,
     ): Boolean {
@@ -716,6 +792,26 @@ object ExternalHttpStreamServer {
             }
 
             onTransferStarted(session.network)
+            // Player pause / stop often leaves the Range open without closing TCP; write
+            // then blocks forever and used to pin activeTransfers + FGS. Abort on no progress.
+            val lastProgressMs = AtomicLong(SystemClock.elapsedRealtime())
+            val stallWatch = if (session.network) {
+                scope.launch {
+                    while (isActive) {
+                        delay(BODY_STALL_CHECK_MS)
+                        val idle = SystemClock.elapsedRealtime() - lastProgressMs.get()
+                        if (idle >= BODY_STALL_MS) {
+                            logcat("ExtHttp") {
+                                "body stall ${idle}ms session=${session.id} name=${entry.displayName} — close socket"
+                            }
+                            runCatching { socket.close() }
+                            break
+                        }
+                    }
+                }
+            } else {
+                null
+            }
             try {
                 val buf = ByteArray(64 * 1024)
                 var remaining = contentLength
@@ -725,6 +821,7 @@ object ExternalHttpStreamServer {
                     val n = body.readAt(offset, buf, 0, want)
                     if (n <= 0) break
                     output.write(buf, 0, n)
+                    lastProgressMs.set(SystemClock.elapsedRealtime())
                     offset += n
                     remaining -= n
                     session.touch()
@@ -739,6 +836,7 @@ object ExternalHttpStreamServer {
                 runCatching { body.close() }
                 return false
             } finally {
+                stallWatch?.cancel()
                 onTransferEnded(session.network)
             }
             runCatching { body.close() }
@@ -864,4 +962,18 @@ object ExternalHttpStreamServer {
 
     /** Idle timeout while reading request line + headers only. */
     private const val REQUEST_HEADER_TIMEOUT_MS = 15_000
+
+    /**
+     * No successful body write for this long → treat player as stopped/paused-with-full-buffer
+     * and abort the socket so [activeTransfers] drops and FGS can shut down.
+     */
+    private const val BODY_STALL_MS = 45_000L
+    private const val BODY_STALL_CHECK_MS = 5_000L
+
+    /**
+     * After last network transfer ends, release warm dual-sticky bodies if no new traffic.
+     * Shorter than [StreamKeepAlivePolicy.FGS_STOP_DELAY_MS] so SMB sockets follow player stop
+     * without waiting the full FGS grace.
+     */
+    private const val WARM_BODY_IDLE_MS = 60_000L
 }

--- a/app/src/main/kotlin/com/hippo/ehviewer/provider/ExternalHttpStreamServer.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/provider/ExternalHttpStreamServer.kt
@@ -41,27 +41,28 @@ import splitties.init.appCtx
  * Same idea as SMB file explorers:
  * `http://127.0.0.1:{port}/s/{sessionId}/{fileName}`
  *
- * Players auto-load sidecars by requesting a sibling URL (swap extension). That does not
- * work with `content://` streamdoc grants; HTTP does.
+ * **Stateless HTTP + timed backend:**
+ * - Session map is a **token** (file registry / sizes / resolveSibling) until idle max age.
+ * - Player may re-Range anytime while the session exists (no need for a live pipe).
+ * - Network video may keep a **warm** dual-sticky body across Ranges to avoid open/close
+ *   cost, but it is released after [BACKEND_IDLE_MS] with no active readers (timeout).
+ * - At most one warm backend per session (Android ≈1 file at a time; cap 2 transfers).
  *
- * - Binds **127.0.0.1 only** (device-local; other apps on the phone can still connect).
- * - Supports **Range** for seek.
- * - HTTP/1.1 keep-alive + optional per-session body cache for network video.
- * - Optional [Session.resolveSibling] serves invented names from the same parent directory.
- * - [FileEntry.sizeBytes] may be −1 (unknown); first GET/HEAD resolves size from the body.
+ * FGS: wake lock only while a body transfer is in flight. Idle FGS (if still running) is
+ * only for process rank so the token stays in RAM + self-stop timer — no CPU work.
  */
 object ExternalHttpStreamServer {
     /**
      * @param sizeBytes known length, or **−1** if unknown (resolved on first open).
-     * @param cacheBody when true, reuse one [StreamBody] across Ranges for this file in the session
-     *   (network video with dual sticky + sliding window). Local/Pfd bodies are not shared.
+     * @param cacheBody when true, reuse one [StreamBody] across Ranges with idle **timeout**
+     *   (network video). Local/Pfd bodies are not cached.
      */
     class FileEntry(
         val displayName: String,
         val mimeType: String,
         sizeBytes: Long,
         val cacheBody: Boolean = false,
-        /** Open a random-access source (may be called once and cached when [cacheBody]). */
+        /** Open a random-access source (cached with idle timeout when [cacheBody]). */
         val open: () -> StreamBody,
     ) {
         private val sizeRef = AtomicLong(sizeBytes)
@@ -120,7 +121,7 @@ object ExternalHttpStreamServer {
         }
     }
 
-    /** In-memory body (e.g. generated m3u8 playlist). */
+    /** In-memory body (e.g. generated m3u playlist). */
     class BytesBody(private val bytes: ByteArray) : StreamBody {
         override val size: Long get() = bytes.size.toLong()
         override fun readAt(offset: Long, buf: ByteArray, off: Int, len: Int): Int {
@@ -147,8 +148,7 @@ object ExternalHttpStreamServer {
     ) {
         private val bodyLock = Any()
         private val bodyCache = HashMap<String, CachedBody>()
-        /** Basename of the single warm dual-sticky video body (at most one per session). */
-        @Volatile private var activeBodyKey: String? = null
+        private val bodyIdleJobs = HashMap<String, Job>()
         /** Live client sockets serving this session (abort on teardown / switch). */
         private val liveSockets = ConcurrentHashMap.newKeySet<Socket>()
 
@@ -184,11 +184,11 @@ object ExternalHttpStreamServer {
         }
 
         /**
-         * Open or reuse a body for [entry]. Caller must [StreamBody.close] when the response ends.
+         * Open a body for this response. Caller must [StreamBody.close] when the response ends.
          *
-         * Network video ([FileEntry.cacheBody]): keep **one** warm dual-sticky source for the
-         * current file (Range reuse). Switching files / sessions closes the previous sticky pair
-         * so 6 opens do not leave 12 SMB connections.
+         * [FileEntry.cacheBody]: reuse one warm backend across Ranges (open/close is costly on
+         * SMB). Released after [BACKEND_IDLE_MS] with no active readers — not held forever.
+         * At most one warm cached file per session (playlist hop closes the previous idle body).
          */
         fun acquireBody(entry: FileEntry): StreamBody {
             touch()
@@ -199,8 +199,8 @@ object ExternalHttpStreamServer {
             }
             val key = pathKey(entry.displayName)
             synchronized(bodyLock) {
-                activeBodyKey = key
-                // Drop idle sticky bodies for other files in this session (playlist hop).
+                cancelBodyIdleJob(key)
+                // Only one warm backend: drop other files that are idle (refs==0).
                 evictIdleBodiesExcept(key)
                 bodyCache[key]?.let { cached ->
                     cached.refs.incrementAndGet()
@@ -221,36 +221,56 @@ object ExternalHttpStreamServer {
                 k != keepKey && c.refs.get() == 0
             }
             for ((k, c) in doomed) {
+                cancelBodyIdleJob(k)
                 bodyCache.remove(k)
                 runCatching { c.body.close() }
+                logcat("ExtHttp") { "evict warm body session=$id file=$k" }
             }
         }
 
         private fun releaseBody(key: String, cached: CachedBody) {
             synchronized(bodyLock) {
                 if (cached.refs.decrementAndGet() > 0) return
-                // No longer the active play file → close sticky immediately (playlist switched).
-                if (activeBodyKey != key) {
-                    if (bodyCache[key] === cached) bodyCache.remove(key)
-                    runCatching { cached.body.close() }
-                    return
-                }
-                // Active file: keep warm for Range reuse until session ends or another file opens.
+                // Keep warm for seeks / next Range; close only after idle timeout.
+                scheduleBodyIdleClose(key, cached)
             }
         }
 
+        private fun cancelBodyIdleJob(key: String) {
+            bodyIdleJobs.remove(key)?.cancel()
+        }
+
+        private fun scheduleBodyIdleClose(key: String, cached: CachedBody) {
+            cancelBodyIdleJob(key)
+            bodyIdleJobs[key] = scope.launch {
+                delay(BACKEND_IDLE_MS)
+                synchronized(bodyLock) {
+                    if (bodyCache[key] !== cached || cached.refs.get() > 0) return@synchronized
+                    bodyCache.remove(key)
+                    bodyIdleJobs.remove(key)
+                    runCatching { cached.body.close() }
+                    logcat("ExtHttp") {
+                        "warm backend idle timeout ${BACKEND_IDLE_MS}ms session=$id file=$key"
+                    }
+                }
+            }
+        }
+
+        /**
+         * Abort client sockets and close any warm backends (session replace / prune / FGS stop).
+         */
         fun closeBodies() {
-            // Unblock stalled body writes so activeTransfers can drop and FGS can stop.
             for (socket in liveSockets.toList()) {
                 runCatching { socket.close() }
             }
             liveSockets.clear()
             synchronized(bodyLock) {
+                for (job in bodyIdleJobs.values) job.cancel()
+                bodyIdleJobs.clear()
                 for ((_, cached) in bodyCache) {
                     runCatching { cached.body.close() }
                 }
                 bodyCache.clear()
-                activeBodyKey = null
             }
         }
 
@@ -261,7 +281,7 @@ object ExternalHttpStreamServer {
         }
 
         /**
-         * Shared session body: [close] only releases the ref; real close on session teardown.
+         * Shared session body: [close] releases a ref and arms idle timeout (not immediate SMB drop).
          * Serializes [readAt] so concurrent Ranges do not race sticky seek state.
          */
         private inner class RefBody(
@@ -301,15 +321,13 @@ object ExternalHttpStreamServer {
     private val activeTransfers = AtomicInteger(0)
     private val keepAliveLock = Any()
     private var stopKeepAliveJob: Job? = null
-    private var warmBodyJob: Job? = null
     private var pruneJob: Job? = null
 
     /**
-     * Live **network HTTP body transfers** only (for FGS wake lock / screen-on).
+     * In-flight network HTTP **body** transfers (wake lock / screen-on).
      *
-     * Counts in-flight GET body streams (not warm sticky bodies, not idle sessions).
-     * Player pause/stop that leaves a half-open Range is aborted by [BODY_STALL_MS] so this
-     * counter cannot stick forever.
+     * Warm backends and idle sessions do **not** count. Stall abort ([BODY_STALL_MS]) prevents
+     * half-open Ranges from pinning this counter forever.
      */
     fun networkActivityCount(): Int = activeTransfers.get()
 
@@ -406,18 +424,16 @@ object ExternalHttpStreamServer {
 
     // region keep-alive
     //
-    // Match streamdoc FD semantics:
-    // - Session map stays for resume until idle max age (~20 min limited; activity-based).
-    // - FGS + wake lock only while a network transfer is in flight, plus short reopen grace.
-    // - Limited mode drops sticky SMB/WebDAV when idle; next GET reconnects.
+    // HTTP session token stays in the map until prune (resume without warm SMB).
+    // Warm backend: per-body idle timeout ([BACKEND_IDLE_MS]), not open/close every Range.
+    // FGS: wake lock only during activeTransfers. Idle FGS = token RAM + self-stop only.
 
     private fun onNetworkSessionRegistered(context: Context = appCtx) {
-        // Player is about to open the URI — brief FGS window until first Range or grace expires.
+        // Brief FGS so the process is not frozen before the first Range (token in RAM).
+        // No wake lock needed until a transfer starts (onStartCommand checks activity).
         synchronized(keepAliveLock) {
             stopKeepAliveJob?.cancel()
             stopKeepAliveJob = null
-            warmBodyJob?.cancel()
-            warmBodyJob = null
             StreamKeepAliveService.start(context)
         }
         maybeStopKeepAliveLater()
@@ -430,8 +446,6 @@ object ExternalHttpStreamServer {
         synchronized(keepAliveLock) {
             stopKeepAliveJob?.cancel()
             stopKeepAliveJob = null
-            warmBodyJob?.cancel()
-            warmBodyJob = null
             StreamKeepAliveService.start(context)
         }
     }
@@ -441,19 +455,17 @@ object ExternalHttpStreamServer {
         val n = activeTransfers.updateAndGet { (it - 1).coerceAtLeast(0) }
         logcat("ExtHttp") { "transfer end active=$n" }
         if (n == 0) {
-            // Drop CPU wake immediately; FGS stops after short grace (sessions still valid).
+            // No active HTTP → drop wake lock immediately. FGS may remain briefly for token
+            // + self-shutdown only (no CPU work). Warm SMB times out separately on the body.
             StreamKeepAliveService.onNetworkIdle()
             maybeStopKeepAliveLater()
-            maybeReleaseWarmBodiesLater()
         }
     }
 
     /**
-     * After last network transfer (or session open with no traffic), stop FGS once the
-     * reopen grace elapses — **even if sessions remain** for later resume.
-     *
-     * Always releases warm HTTP sticky bodies when FGS stops (HTTP has no long-lived FD;
-     * next Range reopens dual sticky). Matches player stop / long pause / app switch.
+     * After last network transfer (or session open with no traffic), stop FGS once grace
+     * elapses. Session map can still exist until prune if process survives; next open
+     * re-registers. On stop: tear down any leftover warm backends (token remains until prune).
      */
     private fun maybeStopKeepAliveLater(context: Context = appCtx) {
         synchronized(keepAliveLock) {
@@ -465,48 +477,17 @@ object ExternalHttpStreamServer {
                         StreamDocumentRegistry.networkOpenCount() == 0
                     ) {
                         StreamKeepAliveService.stop(context)
-                        releaseNetworkHttpBodies("fgs_idle")
+                        // FGS ended: drop leftover warm backends (idle timeout may already have).
+                        for (session in sessions.values) {
+                            if (session.network) session.closeBodies()
+                        }
+                        if (StreamKeepAlivePolicy.dropNetworkOnScreenOff()) {
+                            StreamKeepAlivePolicy.dropStickyNetwork("http_fgs_stop")
+                        }
                         stopKeepAliveJob = null
-                        warmBodyJob = null
                     }
                 }
             }
-        }
-    }
-
-    /**
-     * Drop dual-sticky video bodies sooner than full FGS grace when the player is not
-     * pulling data (switch file / stop / long buffer). FGS may still run until grace ends.
-     */
-    private fun maybeReleaseWarmBodiesLater() {
-        synchronized(keepAliveLock) {
-            warmBodyJob?.cancel()
-            warmBodyJob = scope.launch {
-                delay(WARM_BODY_IDLE_MS)
-                synchronized(keepAliveLock) {
-                    if (activeTransfers.get() == 0) {
-                        releaseNetworkHttpBodies("transfer_idle")
-                    }
-                    warmBodyJob = null
-                }
-            }
-        }
-    }
-
-    private fun releaseNetworkHttpBodies(reason: String) {
-        var closed = 0
-        for (session in sessions.values) {
-            if (session.network) {
-                session.closeBodies()
-                closed++
-            }
-        }
-        if (closed > 0) {
-            logcat("ExtHttp") { "released warm network bodies ($reason) sessions=$closed" }
-        }
-        // Limited mode also force-drops any leftover sticky sockets (Fuse + HTTP).
-        if (StreamKeepAlivePolicy.dropNetworkOnScreenOff()) {
-            StreamKeepAlivePolicy.dropStickyNetwork(reason)
         }
     }
 
@@ -965,15 +946,14 @@ object ExternalHttpStreamServer {
 
     /**
      * No successful body write for this long → treat player as stopped/paused-with-full-buffer
-     * and abort the socket so [activeTransfers] drops and FGS can shut down.
+     * and abort the socket so [activeTransfers] drops (wake lock / FGS activity ends).
      */
     private const val BODY_STALL_MS = 45_000L
     private const val BODY_STALL_CHECK_MS = 5_000L
 
     /**
-     * After last network transfer ends, release warm dual-sticky bodies if no new traffic.
-     * Shorter than [StreamKeepAlivePolicy.FGS_STOP_DELAY_MS] so SMB sockets follow player stop
-     * without waiting the full FGS grace.
+     * After last reader releases a warm network body, keep dual sticky this long for seeks /
+     * next Range (open/close is costly). Then close backend. Session token still valid for resume.
      */
-    private const val WARM_BODY_IDLE_MS = 60_000L
+    private const val BACKEND_IDLE_MS = 90_000L
 }

--- a/app/src/main/kotlin/com/hippo/ehviewer/provider/ExternalHttpStreamServer.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/provider/ExternalHttpStreamServer.kt
@@ -1,6 +1,7 @@
 package com.hippo.ehviewer.provider
 
 import android.content.Context
+import android.net.TrafficStats
 import android.net.Uri
 import android.os.ParcelFileDescriptor
 import android.os.SystemClock
@@ -312,7 +313,20 @@ object ExternalHttpStreamServer {
         60L,
         TimeUnit.SECONDS,
         SynchronousQueue(),
-        { runnable -> Thread(runnable, "ext-http-stream").apply { isDaemon = true } },
+        { runnable ->
+            Thread(
+                {
+                    // Tag before any socket I/O on this worker (StrictMode UntaggedSocketViolation).
+                    TrafficStats.setThreadStatsTag(LOOPBACK_HTTP_TRAFFIC_TAG)
+                    try {
+                        runnable.run()
+                    } finally {
+                        TrafficStats.clearThreadStatsTag()
+                    }
+                },
+                "ext-http-stream",
+            ).apply { isDaemon = true }
+        },
         ThreadPoolExecutor.AbortPolicy(),
     )
 
@@ -343,6 +357,8 @@ object ExternalHttpStreamServer {
         serverSocket = ss
         acceptThread = Thread(
             {
+                // Accept() creates sockets under this thread's tag (StrictMode).
+                TrafficStats.setThreadStatsTag(LOOPBACK_HTTP_TRAFFIC_TAG)
                 try {
                     while (!ss.isClosed) {
                         val socket = try {
@@ -350,6 +366,7 @@ object ExternalHttpStreamServer {
                         } catch (_: Throwable) {
                             break
                         }
+                        runCatching { TrafficStats.tagSocket(socket) }
                         runCatching {
                             connectionPool.execute { handleClient(socket) }
                         }.onFailure {
@@ -359,6 +376,8 @@ object ExternalHttpStreamServer {
                     }
                 } catch (e: Throwable) {
                     logcat("ExtHttp", e)
+                } finally {
+                    TrafficStats.clearThreadStatsTag()
                 }
             },
             "ext-http-accept",
@@ -1009,6 +1028,9 @@ object ExternalHttpStreamServer {
 
     /** Idle timeout while reading request line + headers only. */
     private const val REQUEST_HEADER_TIMEOUT_MS = 15_000
+
+    /** TrafficStats tag for loopback HTTP ("LHTTP" truncated). Must be set before accept/create. */
+    private const val LOOPBACK_HTTP_TRAFFIC_TAG = 0x4C485454
 
     /**
      * No successful body write for this long → treat player as stopped/paused-with-full-buffer

--- a/app/src/main/kotlin/com/hippo/ehviewer/provider/ExternalHttpStreamServer.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/provider/ExternalHttpStreamServer.kt
@@ -138,6 +138,11 @@ object ExternalHttpStreamServer {
     class Session(
         val id: String,
         val network: Boolean,
+        /**
+         * Directory identity for reuse across video opens in the same folder
+         * (e.g. `smb:3:path/to/dir`, `local:/sdcard/Movies`).
+         */
+        val dirKey: String,
         val files: ConcurrentHashMap<String, FileEntry> = ConcurrentHashMap(),
         /**
          * On-demand open for a sibling basename not yet in [files]
@@ -365,21 +370,53 @@ object ExternalHttpStreamServer {
         port
     }
 
-    fun newSession(network: Boolean): Session {
+    /**
+     * Find a live session for [dirKey], or null if pruned / never opened.
+     */
+    fun findSessionByDirKey(dirKey: String): Session? {
+        val key = dirKey.trim()
+        if (key.isEmpty()) return null
+        return sessions.values.firstOrNull { it.dirKey == key }?.also { it.touch() }
+    }
+
+    /**
+     * Reuse the session for [dirKey] if present; otherwise create one.
+     *
+     * Same folder → same session id (player playlist / next video keep working).
+     * New folder → new session; other network sessions are closed to bound sticky SMB.
+     *
+     * @return session and whether it was reused (caller should not destroy a reused session on launch failure).
+     */
+    fun obtainSession(network: Boolean, dirKey: String): Pair<Session, Boolean> {
         ensureStarted()
-        // One network stream at a time: each video uses dual sticky SMB/WebDAV (demand+prefetch).
-        // Leaving prior sessions warm → N opens × 2 connections (e.g. 6 videos = 12 TCP).
+        val key = dirKey.trim().ifEmpty { "dir:${UUID.randomUUID()}" }
+        findSessionByDirKey(key)?.let { existing ->
+            if (network) {
+                onNetworkSessionRegistered()
+            }
+            schedulePrune()
+            logcat("ExtHttp") { "reuse dir session ${existing.id} dirKey=$key files=${existing.files.size}" }
+            return existing to true
+        }
+        // New directory: drop other network sessions so sticky backends do not accumulate.
         if (network) {
             closeOtherNetworkSessions(exceptId = null)
         }
+        // Also replace a prior session with the same dirKey (should not exist after find).
+        for ((id, s) in sessions) {
+            if (s.dirKey == key && sessions.remove(id, s)) {
+                s.closeBodies()
+            }
+        }
         val id = UUID.randomUUID().toString().replace("-", "")
-        val session = Session(id = id, network = network)
+        val session = Session(id = id, network = network, dirKey = key)
         sessions[id] = session
         if (network) {
             onNetworkSessionRegistered()
         }
         schedulePrune()
-        return session
+        logcat("ExtHttp") { "new dir session $id dirKey=$key" }
+        return session to false
     }
 
     /** Drop network HTTP sessions (and their sticky bodies). [exceptId] may be kept. */
@@ -400,6 +437,9 @@ object ExternalHttpStreamServer {
         schedulePrune()
         maybeStopKeepAliveLater()
     }
+
+    /** True if [id] is still registered. */
+    fun hasSession(id: String): Boolean = sessions.containsKey(id)
 
     fun uriFor(sessionId: String, fileName: String): Uri {
         val p = ensureStarted()

--- a/app/src/main/kotlin/com/hippo/ehviewer/provider/ExternalHttpStreamServer.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/provider/ExternalHttpStreamServer.kt
@@ -96,6 +96,20 @@ object ExternalHttpStreamServer {
         }
     }
 
+    /** In-memory body (e.g. generated m3u8 playlist). */
+    class BytesBody(private val bytes: ByteArray) : StreamBody {
+        override val size: Long get() = bytes.size.toLong()
+        override fun readAt(offset: Long, buf: ByteArray, off: Int, len: Int): Int {
+            if (len <= 0) return 0
+            if (offset >= size) return 0
+            val start = offset.toInt()
+            val n = minOf(len, bytes.size - start)
+            System.arraycopy(bytes, start, buf, off, n)
+            return n
+        }
+        override fun close() = Unit
+    }
+
     class Session(
         val id: String,
         val network: Boolean,

--- a/app/src/main/kotlin/com/hippo/ehviewer/provider/ExternalHttpStreamServer.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/provider/ExternalHttpStreamServer.kt
@@ -25,6 +25,7 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.SynchronousQueue
 import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
 import kotlinx.coroutines.CoroutineScope
@@ -43,7 +44,7 @@ import splitties.init.appCtx
  * `http://127.0.0.1:{port}/s/{sessionId}/{fileName}`
  *
  * **Stateless HTTP + timed backend:**
- * - Session map is a **token** (file registry / sizes / resolveSibling) until idle max age.
+ * - Session map is a **token** (pre-registered files and sizes) until idle max age.
  * - Player may re-Range anytime while the session exists (no need for a live pipe).
  * - Network video may keep a **warm** dual-sticky body across Ranges to avoid open/close
  *   cost, but it is released after [BACKEND_IDLE_MS] with no active readers (timeout).
@@ -87,8 +88,7 @@ object ExternalHttpStreamServer {
 
     class ArchiveBody(private val source: ArchiveByteSource) : StreamBody {
         override val size: Long get() = source.size
-        override fun readAt(offset: Long, buf: ByteArray, off: Int, len: Int): Int =
-            source.readAt(offset, buf, off, len)
+        override fun readAt(offset: Long, buf: ByteArray, off: Int, len: Int): Int = source.readAt(offset, buf, off, len)
         override fun close() = source.close()
     }
 
@@ -140,22 +140,17 @@ object ExternalHttpStreamServer {
         val id: String,
         val network: Boolean,
         /**
-         * Directory identity for reuse across video opens in the same folder
-         * (e.g. `smb:3:path/to/dir`, `local:/sdcard/Movies`).
+         * Scoped identity for reuse across compatible opens (folder-wide or one-video access).
          */
         val dirKey: String,
         val files: ConcurrentHashMap<String, FileEntry> = ConcurrentHashMap(),
-        /**
-         * On-demand open for a sibling basename not yet in [files]
-         * (player invents `movie.srt` under the same virtual dir).
-         */
-        @Volatile var resolveSibling: ((String) -> FileEntry?)? = null,
         @Volatile var lastAccessMs: Long = SystemClock.elapsedRealtime(),
     ) {
         private val bodyLock = Any()
         private val bodyCache = HashMap<String, CachedBody>()
         private val bodyIdleJobs = HashMap<String, Job>()
-        /** Live client sockets serving this session (abort on teardown / switch). */
+
+        /** Live client sockets serving this session (abort on teardown). */
         private val liveSockets = ConcurrentHashMap.newKeySet<Socket>()
 
         fun touch() {
@@ -169,6 +164,8 @@ object ExternalHttpStreamServer {
         fun detachSocket(socket: Socket) {
             liveSockets.remove(socket)
         }
+
+        fun hasLiveSockets(): Boolean = liveSockets.isNotEmpty()
 
         fun put(entry: FileEntry) {
             files[pathKey(entry.displayName)] = entry
@@ -184,9 +181,7 @@ object ExternalHttpStreamServer {
             files.entries.firstOrNull { it.key.equals(key, ignoreCase = true) }?.value?.let {
                 return it
             }
-            val resolved = resolveSibling?.invoke(fileName) ?: return null
-            files[pathKey(resolved.displayName)] = resolved
-            return resolved
+            return null
         }
 
         /**
@@ -282,6 +277,7 @@ object ExternalHttpStreamServer {
 
         private class CachedBody(val body: StreamBody) {
             val refs = AtomicInteger(0)
+
             /** Shared so concurrent Range holders serialize sticky seek/read. */
             val readLock = Any()
         }
@@ -294,13 +290,16 @@ object ExternalHttpStreamServer {
             private val key: String,
             private val cached: CachedBody,
         ) : StreamBody {
+            private val closed = AtomicBoolean(false)
+
             override val size: Long get() = cached.body.size
-            override fun readAt(offset: Long, buf: ByteArray, off: Int, len: Int): Int =
-                synchronized(cached.readLock) {
-                    cached.body.readAt(offset, buf, off, len)
-                }
+            override fun readAt(offset: Long, buf: ByteArray, off: Int, len: Int): Int = synchronized(cached.readLock) {
+                cached.body.readAt(offset, buf, off, len)
+            }
             override fun close() {
-                releaseBody(key, cached)
+                if (closed.compareAndSet(false, true)) {
+                    releaseBody(key, cached)
+                }
             }
         }
     }
@@ -338,7 +337,9 @@ object ExternalHttpStreamServer {
     private var port: Int = -1
 
     private val activeTransfers = AtomicInteger(0)
+    private val sessionLock = Any()
     private val keepAliveLock = Any()
+    private val pruneLock = Any()
     private var stopKeepAliveJob: Job? = null
     private var pruneJob: Job? = null
 
@@ -411,25 +412,29 @@ object ExternalHttpStreamServer {
     fun obtainSession(network: Boolean, dirKey: String): Pair<Session, Boolean> {
         ensureStarted()
         val key = dirKey.trim().ifEmpty { "dir:${UUID.randomUUID()}" }
-        findSessionByDirKey(key)?.let { existing ->
-            if (network) {
-                onNetworkSessionRegistered()
+        val result = synchronized(sessionLock) {
+            findSessionByDirKey(key)?.let { existing ->
+                return@synchronized existing to true
             }
-            schedulePrune()
-            logcat("ExtHttp") { "reuse dir session ${existing.id} dirKey=$key files=${existing.files.size}" }
-            return existing to true
+            val id = UUID.randomUUID().toString().replace("-", "")
+            val session = Session(id = id, network = network, dirKey = key)
+            sessions[id] = session
+            session to false
         }
-        val id = UUID.randomUUID().toString().replace("-", "")
-        val session = Session(id = id, network = network, dirKey = key)
-        sessions[id] = session
         if (network) {
             onNetworkSessionRegistered()
         }
-        // Soft cap: drop oldest idle sessions (no live sockets) when over limit.
-        pruneStale()
+        if (result.second) {
+            logcat("ExtHttp") {
+                "reuse dir session ${result.first.id} dirKey=$key files=${result.first.files.size}"
+            }
+        } else {
+            // Soft cap: drop oldest idle sessions (no live sockets) when over limit.
+            pruneStale(protectedSessionId = result.first.id)
+            logcat("ExtHttp") { "new dir session ${result.first.id} dirKey=$key" }
+        }
         schedulePrune()
-        logcat("ExtHttp") { "new dir session $id dirKey=$key" }
-        return session to false
+        return result
     }
 
     fun removeSession(id: String) {
@@ -477,6 +482,7 @@ object ExternalHttpStreamServer {
             stopKeepAliveJob = null
             StreamKeepAliveService.start(context)
         }
+        StreamKeepAliveService.onNetworkActivityChanged()
         maybeStopKeepAliveLater()
     }
 
@@ -489,16 +495,15 @@ object ExternalHttpStreamServer {
             stopKeepAliveJob = null
             StreamKeepAliveService.start(context)
         }
+        StreamKeepAliveService.onNetworkActivityChanged()
     }
 
     private fun onTransferEnded(network: Boolean) {
         if (!network) return
         val n = activeTransfers.updateAndGet { (it - 1).coerceAtLeast(0) }
         logcat("ExtHttp") { "transfer end active=$n" }
+        StreamKeepAliveService.onNetworkActivityChanged()
         if (n == 0) {
-            // No active HTTP → drop wake lock immediately. FGS may remain briefly for token
-            // + self-shutdown only (no CPU work). Warm SMB times out separately on the body.
-            StreamKeepAliveService.onNetworkIdle()
             maybeStopKeepAliveLater()
         }
     }
@@ -536,17 +541,22 @@ object ExternalHttpStreamServer {
         val maxAge = StreamKeepAlivePolicy.tokenMaxAgeMs()
         val next = sessions.values.minOfOrNull { maxAge - (nowMs - it.lastAccessMs) }
             ?.coerceAtLeast(1L)
-        pruneJob?.cancel()
-        pruneJob = next?.let { delayMs ->
-            scope.launch {
-                delay(delayMs)
-                pruneStale()
-                schedulePrune()
+        synchronized(pruneLock) {
+            pruneJob?.cancel()
+            pruneJob = next?.let { delayMs ->
+                scope.launch {
+                    delay(delayMs)
+                    pruneStale()
+                    schedulePrune()
+                }
             }
         }
     }
 
-    fun pruneStale(nowMs: Long = SystemClock.elapsedRealtime()) {
+    fun pruneStale(
+        nowMs: Long = SystemClock.elapsedRealtime(),
+        protectedSessionId: String? = null,
+    ) {
         val maxAge = StreamKeepAlivePolicy.tokenMaxAgeMs()
         // lastAccess is touched on every request/byte progress — idle budget is activity-based.
         for ((id, session) in sessions) {
@@ -560,6 +570,7 @@ object ExternalHttpStreamServer {
         if (sessions.size > MAX_SESSIONS) {
             val overflow = sessions.size - MAX_SESSIONS
             sessions.entries
+                .filterNot { (id, session) -> id == protectedSessionId || session.hasLiveSockets() }
                 .sortedBy { it.value.lastAccessMs }
                 .take(overflow)
                 .forEach { (id, session) ->

--- a/app/src/main/kotlin/com/hippo/ehviewer/provider/ExternalHttpStreamServer.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/provider/ExternalHttpStreamServer.kt
@@ -17,6 +17,7 @@ import java.io.RandomAccessFile
 import java.net.InetAddress
 import java.net.ServerSocket
 import java.net.Socket
+import java.net.SocketTimeoutException
 import java.net.URLDecoder
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
@@ -24,6 +25,7 @@ import java.util.concurrent.SynchronousQueue
 import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -43,17 +45,37 @@ import splitties.init.appCtx
  *
  * - Binds **127.0.0.1 only** (device-local; other apps on the phone can still connect).
  * - Supports **Range** for seek.
- * - Optional [Session.resolveSibling] serves invented names (e.g. `.srt` when only `.ass`
- *   was pre-registered) from the same remote/local parent directory.
+ * - HTTP/1.1 keep-alive + optional per-session body cache for network video.
+ * - Optional [Session.resolveSibling] serves invented names from the same parent directory.
+ * - [FileEntry.sizeBytes] may be −1 (unknown); first GET/HEAD resolves size from the body.
  */
 object ExternalHttpStreamServer {
-    data class FileEntry(
+    /**
+     * @param sizeBytes known length, or **−1** if unknown (resolved on first open).
+     * @param cacheBody when true, reuse one [StreamBody] across Ranges for this file in the session
+     *   (network video with dual sticky + sliding window). Local/Pfd bodies are not shared.
+     */
+    class FileEntry(
         val displayName: String,
         val mimeType: String,
-        val sizeBytes: Long,
-        /** Open a fresh random-access source for this response (may be called per Range). */
+        sizeBytes: Long,
+        val cacheBody: Boolean = false,
+        /** Open a random-access source (may be called once and cached when [cacheBody]). */
         val open: () -> StreamBody,
-    )
+    ) {
+        private val sizeRef = AtomicLong(sizeBytes)
+
+        /** Known length, or −1 until first successful open. */
+        var sizeBytes: Long
+            get() = sizeRef.get()
+            set(value) {
+                sizeRef.set(value)
+            }
+
+        fun publishSize(size: Long) {
+            if (size >= 1L) sizeRef.updateAndGet { cur -> if (cur >= 1L) cur else size }
+        }
+    }
 
     sealed interface StreamBody : AutoCloseable {
         val size: Long
@@ -62,7 +84,8 @@ object ExternalHttpStreamServer {
 
     class ArchiveBody(private val source: ArchiveByteSource) : StreamBody {
         override val size: Long get() = source.size
-        override fun readAt(offset: Long, buf: ByteArray, off: Int, len: Int): Int = source.readAt(offset, buf, off, len)
+        override fun readAt(offset: Long, buf: ByteArray, off: Int, len: Int): Int =
+            source.readAt(offset, buf, off, len)
         override fun close() = source.close()
     }
 
@@ -121,6 +144,11 @@ object ExternalHttpStreamServer {
         @Volatile var resolveSibling: ((String) -> FileEntry?)? = null,
         @Volatile var lastAccessMs: Long = SystemClock.elapsedRealtime(),
     ) {
+        private val bodyLock = Any()
+        private val bodyCache = HashMap<String, CachedBody>()
+        /** Basename of the single warm dual-sticky video body (at most one per session). */
+        @Volatile private var activeBodyKey: String? = null
+
         fun touch() {
             lastAccessMs = SystemClock.elapsedRealtime()
         }
@@ -142,6 +170,96 @@ object ExternalHttpStreamServer {
             val resolved = resolveSibling?.invoke(fileName) ?: return null
             files[pathKey(resolved.displayName)] = resolved
             return resolved
+        }
+
+        /**
+         * Open or reuse a body for [entry]. Caller must [StreamBody.close] when the response ends.
+         *
+         * Network video ([FileEntry.cacheBody]): keep **one** warm dual-sticky source for the
+         * current file (Range reuse). Switching files / sessions closes the previous sticky pair
+         * so 6 opens do not leave 12 SMB connections.
+         */
+        fun acquireBody(entry: FileEntry): StreamBody {
+            touch()
+            if (!entry.cacheBody) {
+                return entry.open().also { body ->
+                    entry.publishSize(body.size)
+                }
+            }
+            val key = pathKey(entry.displayName)
+            synchronized(bodyLock) {
+                activeBodyKey = key
+                // Drop idle sticky bodies for other files in this session (playlist hop).
+                evictIdleBodiesExcept(key)
+                bodyCache[key]?.let { cached ->
+                    cached.refs.incrementAndGet()
+                    entry.publishSize(cached.body.size)
+                    return RefBody(key, cached)
+                }
+                val body = entry.open()
+                entry.publishSize(body.size)
+                val cached = CachedBody(body)
+                cached.refs.set(1)
+                bodyCache[key] = cached
+                return RefBody(key, cached)
+            }
+        }
+
+        private fun evictIdleBodiesExcept(keepKey: String) {
+            val doomed = bodyCache.entries.filter { (k, c) ->
+                k != keepKey && c.refs.get() == 0
+            }
+            for ((k, c) in doomed) {
+                bodyCache.remove(k)
+                runCatching { c.body.close() }
+            }
+        }
+
+        private fun releaseBody(key: String, cached: CachedBody) {
+            synchronized(bodyLock) {
+                if (cached.refs.decrementAndGet() > 0) return
+                // No longer the active play file → close sticky immediately (playlist switched).
+                if (activeBodyKey != key) {
+                    if (bodyCache[key] === cached) bodyCache.remove(key)
+                    runCatching { cached.body.close() }
+                    return
+                }
+                // Active file: keep warm for Range reuse until session ends or another file opens.
+            }
+        }
+
+        fun closeBodies() {
+            synchronized(bodyLock) {
+                for ((_, cached) in bodyCache) {
+                    runCatching { cached.body.close() }
+                }
+                bodyCache.clear()
+                activeBodyKey = null
+            }
+        }
+
+        private class CachedBody(val body: StreamBody) {
+            val refs = AtomicInteger(0)
+            /** Shared so concurrent Range holders serialize sticky seek/read. */
+            val readLock = Any()
+        }
+
+        /**
+         * Shared session body: [close] only releases the ref; real close on session teardown.
+         * Serializes [readAt] so concurrent Ranges do not race sticky seek state.
+         */
+        private inner class RefBody(
+            private val key: String,
+            private val cached: CachedBody,
+        ) : StreamBody {
+            override val size: Long get() = cached.body.size
+            override fun readAt(offset: Long, buf: ByteArray, off: Int, len: Int): Int =
+                synchronized(cached.readLock) {
+                    cached.body.readAt(offset, buf, off, len)
+                }
+            override fun close() {
+                releaseBody(key, cached)
+            }
         }
     }
 
@@ -214,6 +332,11 @@ object ExternalHttpStreamServer {
 
     fun newSession(network: Boolean): Session {
         ensureStarted()
+        // One network stream at a time: each video uses dual sticky SMB/WebDAV (demand+prefetch).
+        // Leaving prior sessions warm → N opens × 2 connections (e.g. 6 videos = 12 TCP).
+        if (network) {
+            closeOtherNetworkSessions(exceptId = null)
+        }
         val id = UUID.randomUUID().toString().replace("-", "")
         val session = Session(id = id, network = network)
         sessions[id] = session
@@ -224,8 +347,21 @@ object ExternalHttpStreamServer {
         return session
     }
 
+    /** Drop network HTTP sessions (and their sticky bodies). [exceptId] may be kept. */
+    private fun closeOtherNetworkSessions(exceptId: String?) {
+        for ((id, session) in sessions) {
+            if (!session.network) continue
+            if (exceptId != null && id == exceptId) continue
+            if (sessions.remove(id, session)) {
+                session.closeBodies()
+                logcat("ExtHttp") { "closed prior network session $id (sticky release)" }
+            }
+        }
+    }
+
     fun removeSession(id: String) {
-        sessions.remove(id)
+        val removed = sessions.remove(id)
+        removed?.closeBodies()
         schedulePrune()
         maybeStopKeepAliveLater()
     }
@@ -307,6 +443,10 @@ object ExternalHttpStreamServer {
                         if (StreamKeepAlivePolicy.dropNetworkOnScreenOff() &&
                             sessions.values.any { it.network }
                         ) {
+                            // Close warm HTTP bodies so sticky handles drop with the pool.
+                            for (session in sessions.values) {
+                                if (session.network) session.closeBodies()
+                            }
                             StreamKeepAlivePolicy.dropStickyNetwork("http_idle")
                         }
                         stopKeepAliveJob = null
@@ -335,7 +475,9 @@ object ExternalHttpStreamServer {
         // lastAccess is touched on every request/byte progress — idle budget is activity-based.
         for ((id, session) in sessions) {
             if (nowMs - session.lastAccessMs >= maxAge) {
-                sessions.remove(id, session)
+                if (sessions.remove(id, session)) {
+                    session.closeBodies()
+                }
             }
         }
         // Soft cap
@@ -344,7 +486,11 @@ object ExternalHttpStreamServer {
             sessions.entries
                 .sortedBy { it.value.lastAccessMs }
                 .take(overflow)
-                .forEach { sessions.remove(it.key, it.value) }
+                .forEach { (id, session) ->
+                    if (sessions.remove(id, session)) {
+                        session.closeBodies()
+                    }
+                }
         }
         // Do not re-arm FGS from prune; only stop if already idle.
         if (activeTransfers.get() == 0) {
@@ -356,21 +502,38 @@ object ExternalHttpStreamServer {
 
     private fun handleClient(socket: Socket) {
         try {
-            // Bound header parse only; body streaming can idle between player Range chunks.
-            socket.soTimeout = REQUEST_HEADER_TIMEOUT_MS
             val input = BufferedInputStream(socket.getInputStream())
             val output = BufferedOutputStream(socket.getOutputStream())
-            val request = readRequest(input) ?: run {
-                writeSimple(output, 400, "Bad Request")
-                return
+            var requests = 0
+            while (requests < MAX_REQUESTS_PER_CONNECTION) {
+                socket.soTimeout = REQUEST_HEADER_TIMEOUT_MS
+                val request = try {
+                    readRequest(input)
+                } catch (_: SocketTimeoutException) {
+                    break
+                } catch (_: IOException) {
+                    break
+                } ?: break
+                requests++
+                // Long movie Range replies must not die on SO_TIMEOUT mid-body.
+                socket.soTimeout = 0
+                val moreAllowed = requests < MAX_REQUESTS_PER_CONNECTION
+                val clientWantsKeepAlive = wantsKeepAlive(request) && moreAllowed
+                val keepAlive = when (request.method) {
+                    "GET", "HEAD" -> serve(
+                        request,
+                        output,
+                        headOnly = request.method == "HEAD",
+                        preferKeepAlive = clientWantsKeepAlive,
+                    )
+                    else -> {
+                        writeSimple(output, 405, "Method Not Allowed", keepAlive = false)
+                        false
+                    }
+                }
+                output.flush()
+                if (!keepAlive) break
             }
-            // Long movie Range replies must not die on SO_TIMEOUT mid-body.
-            socket.soTimeout = 0
-            when (request.method) {
-                "GET", "HEAD" -> serve(request, output, headOnly = request.method == "HEAD")
-                else -> writeSimple(output, 405, "Method Not Allowed")
-            }
-            output.flush()
         } catch (e: Throwable) {
             if (e !is IOException) logcat("ExtHttp", e)
         } finally {
@@ -381,8 +544,17 @@ object ExternalHttpStreamServer {
     private data class HttpRequest(
         val method: String,
         val path: String,
+        val httpVersion: String,
         val headers: Map<String, String>,
     )
+
+    private fun wantsKeepAlive(request: HttpRequest): Boolean {
+        val conn = request.headers["connection"]?.lowercase().orEmpty()
+        if (conn.contains("close")) return false
+        if (conn.contains("keep-alive")) return true
+        // HTTP/1.1 default is keep-alive.
+        return request.httpVersion.startsWith("HTTP/1.1")
+    }
 
     private fun readRequest(input: InputStream): HttpRequest? {
         val line = readLine(input, MAX_REQUEST_LINE_LENGTH) ?: return null
@@ -390,6 +562,7 @@ object ExternalHttpStreamServer {
         if (parts.size != 3 || !parts[2].startsWith("HTTP/")) return null
         val method = parts[0].uppercase()
         val path = parts[1]
+        val httpVersion = parts[2].trim()
         val headers = LinkedHashMap<String, String>()
         var headerCount = 0
         while (true) {
@@ -403,7 +576,7 @@ object ExternalHttpStreamServer {
                 headers[name] = value
             }
         }
-        return HttpRequest(method, path, headers)
+        return HttpRequest(method, path, httpVersion, headers)
     }
 
     private fun readLine(input: InputStream, maxLength: Int): String? {
@@ -420,82 +593,103 @@ object ExternalHttpStreamServer {
         return sb.toString()
     }
 
-    private fun serve(request: HttpRequest, output: OutputStream, headOnly: Boolean) {
+    /**
+     * @return whether the connection should stay open for another request.
+     */
+    private fun serve(
+        request: HttpRequest,
+        output: OutputStream,
+        headOnly: Boolean,
+        preferKeepAlive: Boolean,
+    ): Boolean {
         // /s/{sessionId}[/] → directory index of registered media
         // /s/{sessionId}/{fileName} → file body (Range)
         val rawPath = request.path.substringBefore('?')
         val segs = runCatching {
             rawPath.trim('/').split('/').map { URLDecoder.decode(it, Charsets.UTF_8) }
         }.getOrElse {
-            writeSimple(output, 400, "Bad Request")
-            return
+            writeSimple(output, 400, "Bad Request", keepAlive = false)
+            return false
         }
         if (segs.isEmpty() || segs[0] != "s") {
-            writeSimple(output, 404, "Not Found")
-            return
+            writeSimple(output, 404, "Not Found", keepAlive = preferKeepAlive)
+            return preferKeepAlive
         }
         if (segs.size == 1) {
-            writeSimple(output, 404, "Not Found")
-            return
+            writeSimple(output, 404, "Not Found", keepAlive = preferKeepAlive)
+            return preferKeepAlive
         }
         val sessionId = segs[1]
         val session = sessions[sessionId]
         if (session == null) {
-            writeSimple(output, 404, "Session expired")
-            return
+            writeSimple(output, 404, "Session expired", keepAlive = preferKeepAlive)
+            return preferKeepAlive
         }
         session.touch()
         // Directory listing (players / next-prev that probe the parent URL).
         if (segs.size == 2 || (segs.size == 3 && segs[2].isEmpty())) {
-            writeDirectoryListing(output, session, headOnly)
-            return
+            writeDirectoryListing(output, session, headOnly, preferKeepAlive)
+            return preferKeepAlive
         }
         if (segs.size != 3 || !isSafeFileName(segs[2])) {
-            writeSimple(output, 404, "Not Found")
-            return
+            writeSimple(output, 404, "Not Found", keepAlive = preferKeepAlive)
+            return preferKeepAlive
         }
         val fileName = segs[2]
         val entry = session.get(fileName)
         if (entry == null) {
             logcat("ExtHttp") { "404 missing file session=$sessionId name=$fileName" }
-            writeSimple(output, 404, "Not Found")
-            return
+            writeSimple(output, 404, "Not Found", keepAlive = preferKeepAlive)
+            return preferKeepAlive
         }
+
+        val body = try {
+            session.acquireBody(entry)
+        } catch (e: Throwable) {
+            if (e !is IOException) logcat("ExtHttp", e)
+            writeSimple(output, 404, "Not Found", keepAlive = preferKeepAlive)
+            return preferKeepAlive
+        }
+
+        val total = entry.sizeBytes.takeIf { it >= 1L } ?: body.size
+        if (total < 1L) {
+            runCatching { body.close() }
+            writeSimple(output, 404, "Empty", keepAlive = preferKeepAlive)
+            return preferKeepAlive
+        }
+        entry.publishSize(total)
 
         val rangeHeader = request.headers["range"]
-        val total = entry.sizeBytes
-        if (total < 1L) {
-            writeSimple(output, 404, "Empty")
-            return
-        }
-
         val range = parseRange(rangeHeader, total)
         if (!rangeHeader.isNullOrBlank() && range == null) {
+            runCatching { body.close() }
             writeSimple(
                 output,
                 416,
                 "Range Not Satisfiable",
                 extraHeaders = listOf("Content-Range: bytes */$total"),
+                keepAlive = preferKeepAlive,
             )
-            return
+            return preferKeepAlive
         }
         val start = range?.first ?: 0L
         val end = range?.second ?: (total - 1L)
         if (start < 0L || end < start || start >= total) {
+            runCatching { body.close() }
             writeSimple(
                 output,
                 416,
                 "Range Not Satisfiable",
-                extraHeaders = listOf(
-                    "Content-Range: bytes */$total",
-                ),
+                extraHeaders = listOf("Content-Range: bytes */$total"),
+                keepAlive = preferKeepAlive,
             )
-            return
+            return preferKeepAlive
         }
         val contentLength = end - start + 1L
         val status = if (range != null) 206 else 200
         val statusText = if (range != null) "Partial Content" else "OK"
         val mime = entry.mimeType.ifBlank { mimeTypeForFileName(entry.displayName) }
+        val connHeader = if (preferKeepAlive) "keep-alive" else "close"
 
         val headers = buildString {
             append("HTTP/1.1 $status $statusText\r\n")
@@ -507,16 +701,22 @@ object ExternalHttpStreamServer {
             }
             // Real file name for players that read Content-Disposition.
             append("Content-Disposition: inline; filename=\"${escapeHeader(entry.displayName)}\"\r\n")
-            append("Connection: close\r\n")
+            append("Connection: $connHeader\r\n")
+            if (preferKeepAlive) {
+                append("Keep-Alive: timeout=${KEEP_ALIVE_TIMEOUT_SEC}\r\n")
+            }
             append("Cache-Control: no-store\r\n")
             append("\r\n")
         }
-        output.write(headers.toByteArray(Charsets.US_ASCII))
-        if (headOnly) return
-
-        onTransferStarted(session.network)
         try {
-            entry.open().use { body ->
+            output.write(headers.toByteArray(Charsets.US_ASCII))
+            if (headOnly) {
+                runCatching { body.close() }
+                return preferKeepAlive
+            }
+
+            onTransferStarted(session.network)
+            try {
                 val buf = ByteArray(64 * 1024)
                 var remaining = contentLength
                 var offset = start
@@ -529,11 +729,24 @@ object ExternalHttpStreamServer {
                     remaining -= n
                     session.touch()
                 }
+                // Incomplete body → client must not reuse the connection.
+                if (remaining > 0L) {
+                    runCatching { body.close() }
+                    return false
+                }
+            } catch (e: Throwable) {
+                if (e !is IOException) logcat("ExtHttp", e)
+                runCatching { body.close() }
+                return false
+            } finally {
+                onTransferEnded(session.network)
             }
+            runCatching { body.close() }
+            return preferKeepAlive
         } catch (e: Throwable) {
             if (e !is IOException) logcat("ExtHttp", e)
-        } finally {
-            onTransferEnded(session.network)
+            runCatching { body.close() }
+            return false
         }
     }
 
@@ -544,7 +757,7 @@ object ExternalHttpStreamServer {
         if (!header.startsWith("bytes=", ignoreCase = true)) return null
         val spec = header.substring(6).trim()
         if (spec.contains(',')) {
-            // Multi-range not supported — serve full body as 200 by ignoring.
+            // Multi-range not supported — treat as unsatisfiable at call site.
             return null
         }
         val dash = spec.indexOf('-')
@@ -578,6 +791,7 @@ object ExternalHttpStreamServer {
         code: Int,
         message: String,
         extraHeaders: List<String> = emptyList(),
+        keepAlive: Boolean = false,
     ) {
         val body = message.toByteArray(Charsets.UTF_8)
         val sb = StringBuilder()
@@ -585,7 +799,7 @@ object ExternalHttpStreamServer {
         sb.append("Content-Type: text/plain; charset=utf-8\r\n")
         sb.append("Content-Length: ${body.size}\r\n")
         for (h in extraHeaders) sb.append(h).append("\r\n")
-        sb.append("Connection: close\r\n\r\n")
+        sb.append("Connection: ").append(if (keepAlive) "keep-alive" else "close").append("\r\n\r\n")
         output.write(sb.toString().toByteArray(Charsets.US_ASCII))
         output.write(body)
     }
@@ -595,6 +809,7 @@ object ExternalHttpStreamServer {
         output: OutputStream,
         session: Session,
         headOnly: Boolean,
+        keepAlive: Boolean,
     ) {
         val names = session.files.values.map { it.displayName }.distinct().sorted()
         val html = buildString {
@@ -613,7 +828,7 @@ object ExternalHttpStreamServer {
             append("HTTP/1.1 200 OK\r\n")
             append("Content-Type: text/html; charset=utf-8\r\n")
             append("Content-Length: ${body.size}\r\n")
-            append("Connection: close\r\n")
+            append("Connection: ").append(if (keepAlive) "keep-alive" else "close").append("\r\n")
             append("Cache-Control: no-store\r\n")
             append("\r\n")
         }
@@ -639,11 +854,13 @@ object ExternalHttpStreamServer {
     }
 
     private const val MAX_SESSIONS = 16
-    private const val MAX_CONCURRENT_CONNECTIONS = 8
+    private const val MAX_CONCURRENT_CONNECTIONS = 16
     private const val MAX_FILE_NAME_LENGTH = 1024
     private const val MAX_REQUEST_LINE_LENGTH = 4096
     private const val MAX_HEADER_LINE_LENGTH = 8192
     private const val MAX_HEADER_COUNT = 64
+    private const val MAX_REQUESTS_PER_CONNECTION = 100
+    private const val KEEP_ALIVE_TIMEOUT_SEC = 60
 
     /** Idle timeout while reading request line + headers only. */
     private const val REQUEST_HEADER_TIMEOUT_MS = 15_000

--- a/app/src/main/kotlin/com/hippo/ehviewer/provider/ExternalHttpStreamServer.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/provider/ExternalHttpStreamServer.kt
@@ -402,7 +402,9 @@ object ExternalHttpStreamServer {
      * Reuse the session for [dirKey] if present; otherwise create one.
      *
      * Same folder → same session id (player playlist / next video keep working).
-     * New folder → new session; other network sessions are closed to bound sticky SMB.
+     * New folder → **new session**; other dir sessions stay until **idle prune** / soft cap
+     * (not closed just because the user opened another folder). Warm SMB backends still
+     * drop per-body after [BACKEND_IDLE_MS] with no readers.
      *
      * @return session and whether it was reused (caller should not destroy a reused session on launch failure).
      */
@@ -417,37 +419,17 @@ object ExternalHttpStreamServer {
             logcat("ExtHttp") { "reuse dir session ${existing.id} dirKey=$key files=${existing.files.size}" }
             return existing to true
         }
-        // New directory: drop other network sessions so sticky backends do not accumulate.
-        if (network) {
-            closeOtherNetworkSessions(exceptId = null)
-        }
-        // Also replace a prior session with the same dirKey (should not exist after find).
-        for ((id, s) in sessions) {
-            if (s.dirKey == key && sessions.remove(id, s)) {
-                s.closeBodies()
-            }
-        }
         val id = UUID.randomUUID().toString().replace("-", "")
         val session = Session(id = id, network = network, dirKey = key)
         sessions[id] = session
         if (network) {
             onNetworkSessionRegistered()
         }
+        // Soft cap: drop oldest idle sessions (no live sockets) when over limit.
+        pruneStale()
         schedulePrune()
         logcat("ExtHttp") { "new dir session $id dirKey=$key" }
         return session to false
-    }
-
-    /** Drop network HTTP sessions (and their sticky bodies). [exceptId] may be kept. */
-    private fun closeOtherNetworkSessions(exceptId: String?) {
-        for ((id, session) in sessions) {
-            if (!session.network) continue
-            if (exceptId != null && id == exceptId) continue
-            if (sessions.remove(id, session)) {
-                session.closeBodies()
-                logcat("ExtHttp") { "closed prior network session $id (sticky release)" }
-            }
-        }
     }
 
     fun removeSession(id: String) {

--- a/app/src/main/kotlin/com/hippo/ehviewer/provider/ExternalHttpStreamServer.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/provider/ExternalHttpStreamServer.kt
@@ -695,7 +695,7 @@ object ExternalHttpStreamServer {
         val fileName = segs[2]
         val entry = session.get(fileName)
         if (entry == null) {
-            logcat("ExtHttp") { "404 missing file session=$sessionId name=$fileName" }
+            // Players invent many sidecar URLs (.srt/.ass/.sami/…); only pre-listed names exist.
             writeSimple(output, 404, "Not Found", keepAlive = preferKeepAlive)
             return preferKeepAlive
         }
@@ -703,12 +703,20 @@ object ExternalHttpStreamServer {
         val body = try {
             session.acquireBody(entry)
         } catch (e: Throwable) {
-            if (e !is IOException) logcat("ExtHttp", e)
+            // Missing remote file / player subtitle probes: 404 only, no ERROR stack spam.
+            if (e !is IOException && !isBenignNotFound(e)) logcat("ExtHttp", e)
             writeSimple(output, 404, "Not Found", keepAlive = preferKeepAlive)
             return preferKeepAlive
         }
 
-        val total = entry.sizeBytes.takeIf { it >= 1L } ?: body.size
+        val total = try {
+            entry.sizeBytes.takeIf { it >= 1L } ?: body.size
+        } catch (e: Throwable) {
+            runCatching { body.close() }
+            if (e !is IOException && !isBenignNotFound(e)) logcat("ExtHttp", e)
+            writeSimple(output, 404, "Not Found", keepAlive = preferKeepAlive)
+            return preferKeepAlive
+        }
         if (total < 1L) {
             runCatching { body.close() }
             writeSimple(output, 404, "Empty", keepAlive = preferKeepAlive)
@@ -913,6 +921,24 @@ object ExternalHttpStreamServer {
         }
         output.write(headers.toByteArray(Charsets.US_ASCII))
         if (!headOnly) output.write(body)
+    }
+
+    /** SMB/WebDAV “file does not exist” — expected for players inventing subtitle URLs. */
+    private fun isBenignNotFound(t: Throwable): Boolean {
+        var c: Throwable? = t
+        while (c != null) {
+            val msg = c.message.orEmpty()
+            if (msg.contains("STATUS_OBJECT_NAME_NOT_FOUND", ignoreCase = true) ||
+                msg.contains("STATUS_OBJECT_PATH_NOT_FOUND", ignoreCase = true) ||
+                msg.contains("STATUS_NO_SUCH_FILE", ignoreCase = true) ||
+                msg.contains("404", ignoreCase = true) ||
+                msg.contains("Not Found", ignoreCase = true)
+            ) {
+                return true
+            }
+            c = c.cause
+        }
+        return false
     }
 
     private fun escapeHeader(name: String): String = pathKey(name)

--- a/app/src/main/kotlin/com/hippo/ehviewer/provider/StreamDocumentRegistry.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/provider/StreamDocumentRegistry.kt
@@ -134,6 +134,7 @@ object StreamDocumentRegistry {
             // service, and startForegroundService() is idempotent while it is already alive.
             StreamKeepAliveService.start(context)
         }
+        StreamKeepAliveService.onNetworkActivityChanged()
     }
 
     /**
@@ -152,15 +153,17 @@ object StreamDocumentRegistry {
         entry.lastAccessMs = SystemClock.elapsedRealtime()
         synchronized(keepAliveLock) {
             totalNetworkOpen = (totalNetworkOpen - 1).coerceAtLeast(0)
+            StreamKeepAliveService.onNetworkActivityChanged()
             if (totalNetworkOpen == 0) {
                 // Keep the low-priority FGS briefly for URI reopen, but do not keep the CPU
                 // awake during that idle grace period.
-                StreamKeepAliveService.onNetworkIdle()
                 stopKeepAliveJob?.cancel()
                 stopKeepAliveJob = scope.launch {
                     delay(StreamKeepAlivePolicy.fgsStopDelayMs())
                     synchronized(keepAliveLock) {
-                        if (totalNetworkOpen == 0) {
+                        if (totalNetworkOpen == 0 &&
+                            ExternalHttpStreamServer.networkActivityCount() == 0
+                        ) {
                             StreamKeepAliveService.stop(context)
                             stopKeepAliveJob = null
                         }

--- a/app/src/main/kotlin/com/hippo/ehviewer/provider/StreamKeepAlivePolicy.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/provider/StreamKeepAlivePolicy.kt
@@ -11,11 +11,13 @@ import com.hippo.ehviewer.webdav.WebDavClient
  *
  * Limited (default): ~20 min idle session/token budget (activity-based, not a hard clock)
  * + drop sticky transports on screen off / HTTP idle; short FGS grace after last activity.
- * Unlimited (Advanced): long idle + keep sockets across screen off.
+ * Unlimited (Advanced): long idle token age; streamdoc may keep sticky across screen off.
+ * HTTP still releases warm bodies when FGS stops (no long-lived FD).
  *
  * Drop is **resumable**: streamdoc tokens / HTTP sessions stay; next proxy read or HTTP
  * GET reconnects SMB sticky / WebDAV Range (may rebuffer a few seconds on 4K).
- * FGS / wake lock track **live** FDs or HTTP body transfers only — not idle sessions.
+ * FGS / wake lock track **live** FDs or **in-flight HTTP body transfers** only — not idle
+ * sessions or warm body caches. Stalled HTTP Ranges are aborted so FGS can stop.
  */
 object StreamKeepAlivePolicy {
     /** Idle token age when limited. */

--- a/app/src/main/kotlin/com/hippo/ehviewer/provider/StreamKeepAlivePolicy.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/provider/StreamKeepAlivePolicy.kt
@@ -9,15 +9,15 @@ import com.hippo.ehviewer.webdav.WebDavClient
 /**
  * Battery vs reliability knobs for external Fuse **and** loopback HTTP streaming.
  *
- * Limited (default): ~20 min idle session/token budget (activity-based, not a hard clock)
- * + drop sticky transports on screen off / HTTP idle; short FGS grace after last activity.
- * Unlimited (Advanced): long idle token age; streamdoc may keep sticky across screen off.
- * HTTP still releases warm bodies when FGS stops (no long-lived FD).
+ * **Streamdoc (Fuse):** live proxy FDs need sticky + FGS while open; tokens age out separately.
  *
- * Drop is **resumable**: streamdoc tokens / HTTP sessions stay; next proxy read or HTTP
- * GET reconnects SMB sticky / WebDAV Range (may rebuffer a few seconds on 4K).
- * FGS / wake lock track **live** FDs or **in-flight HTTP body transfers** only — not idle
- * sessions or warm body caches. Stalled HTTP Ranges are aborted so FGS can stop.
+ * **HTTP loopback:** session map is a **stateless token** (resume via Range anytime before prune).
+ * Warm SMB is optional with **idle timeout** (open/close every Range is costly) — not required
+ * for correctness. FGS wake lock only while a body transfer is in flight; idle FGS (grace) is
+ * only process rank so the token stays in RAM + self-shutdown — no other CPU work.
+ *
+ * Limited (default): shorter token age + drop sticky on screen off / FGS stop.
+ * Unlimited (Advanced): longer token age; streamdoc may keep sticky across screen off.
  */
 object StreamKeepAlivePolicy {
     /** Idle token age when limited. */

--- a/app/src/main/kotlin/com/hippo/ehviewer/provider/StreamKeepAliveService.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/provider/StreamKeepAliveService.kt
@@ -19,12 +19,12 @@ import com.hippo.ehviewer.R
 import com.hippo.ehviewer.ui.MainActivity
 
 /**
- * Keeps LocalViewer unfrozen while a network [StreamDocumentProvider] proxy FD is open.
+ * Keeps LocalViewer unfrozen while a network stream is active in another app.
  *
- * External players stream SMB/WebDAV over Fuse in **this** process. Without a foreground
- * service the process is cached after ON_STOP, frozen after a few minutes, and reads
- * stall — playback dies and resume fails because the in-memory token / sticky session
- * is gone. Start when the first network proxy is retained; stop when the last is released.
+ * External players stream SMB/WebDAV through either a [StreamDocumentProvider] proxy FD or
+ * [ExternalHttpStreamServer] in **this** process. Without a foreground service the process is
+ * cached after ON_STOP, frozen after a few minutes, and reads stall. Start on network activity;
+ * stop after both transports are idle.
  *
  * Android may time out a `dataSync` FGS. A timed-out service must stop promptly; the
  * existing proxy FD then fails/reopens normally instead of risking RemoteServiceException.
@@ -50,23 +50,17 @@ class StreamKeepAliveService : Service() {
         // startForegroundService() is asynchronous: a short-lived FD / HTTP transfer may
         // already be done. Wake lock only while a proxy FD or HTTP body is live.
         // Idle FGS (HTTP token grace / self-stop): no wake lock, no CPU work.
-        if (StreamDocumentRegistry.networkOpenCount() > 0 ||
-            ExternalHttpStreamServer.networkActivityCount() > 0
-        ) {
-            acquireWakeLock()
-        } else {
-            releaseWakeLock()
-        }
+        updateWakeLockForActivity()
         // The registry and network source are process-local. Restarting only this service
         // after process death cannot restore the URI token or an external player's FD.
         return START_NOT_STICKY
     }
 
     override fun onTimeout(startId: Int, fgsType: Int) {
-        val stillOpen = StreamDocumentRegistry.networkOpenCount() +
-            ExternalHttpStreamServer.networkActivityCount()
+        val openFds = StreamDocumentRegistry.networkOpenCount()
+        val httpTransfers = ExternalHttpStreamServer.networkActivityCount()
         logcat("StreamKeepAlive") {
-            "Foreground service timed out (type=$fgsType) openFds=$stillOpen"
+            "Foreground service timed out (type=$fgsType) openFds=$openFds httpTransfers=$httpTransfers"
         }
         // Android 15+ requires a timed-out dataSync service to stop within a few seconds.
         // Re-promotion does not reset the quota and can crash the app.
@@ -125,6 +119,14 @@ class StreamKeepAliveService : Service() {
         }
     }
 
+    private fun updateWakeLockForActivity() {
+        if (hasActiveNetworkStreams()) {
+            acquireWakeLock()
+        } else {
+            releaseWakeLock()
+        }
+    }
+
     private fun ensureChannel() {
         val nm = getSystemService(NotificationManager::class.java) ?: return
         if (nm.getNotificationChannel(CHANNEL_ID) != null) return
@@ -170,7 +172,10 @@ class StreamKeepAliveService : Service() {
         @Volatile
         private var instance: StreamKeepAliveService? = null
 
-        /** Start or refresh the keep-alive for a live network proxy FD. */
+        private fun hasActiveNetworkStreams(): Boolean = StreamDocumentRegistry.networkOpenCount() > 0 ||
+            ExternalHttpStreamServer.networkActivityCount() > 0
+
+        /** Start or refresh the keep-alive for live network activity. */
         fun start(context: Context) {
             val app = context.applicationContext
             try {
@@ -193,14 +198,14 @@ class StreamKeepAliveService : Service() {
             }.onFailure { logcat("StreamKeepAlive", it) }
         }
 
-        /** Keep the FGS grace period, but never hold the CPU awake with no live proxy FD. */
-        fun onNetworkIdle() {
-            instance?.releaseWakeLock()
+        /** Reconcile the shared wake lock after either stream transport changes activity. */
+        fun onNetworkActivityChanged() {
+            instance?.updateWakeLockForActivity()
         }
 
         /**
          * Limited mode + screen off: drop partial wake lock so the device can sleep.
-         * FGS notification stays if FDs are open so process rank stays elevated for Fuse.
+         * FGS notification stays if a stream is active so process rank remains elevated.
          * [start] re-acquires on screen on / next retain.
          */
         fun onScreenOffConservePower() {

--- a/app/src/main/kotlin/com/hippo/ehviewer/provider/StreamKeepAliveService.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/provider/StreamKeepAliveService.kt
@@ -47,10 +47,9 @@ class StreamKeepAliveService : Service() {
             stopSelf()
             return START_NOT_STICKY
         }
-        // startForegroundService() is asynchronous: a very short-lived external FD / HTTP
-        // transfer may already be done before this callback runs. Preserve the FGS reopen
-        // grace, but only keep the CPU awake while a proxy FD or HTTP body is live —
-        // idle HTTP sessions do not count (battery-friendly, still resumable).
+        // startForegroundService() is asynchronous: a short-lived FD / HTTP transfer may
+        // already be done. Wake lock only while a proxy FD or HTTP body is live.
+        // Idle FGS (HTTP token grace / self-stop): no wake lock, no CPU work.
         if (StreamDocumentRegistry.networkOpenCount() > 0 ||
             ExternalHttpStreamServer.networkActivityCount() > 0
         ) {

--- a/app/src/main/kotlin/com/hippo/ehviewer/ui/OpenFileExternally.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/ui/OpenFileExternally.kt
@@ -403,7 +403,7 @@ object OpenFileExternally {
             displayName = displayName,
             mimeType = mimeType,
             sizeBytes = sizeBytes,
-            // Dual sticky + sliding window; body reused across Ranges in the HTTP session.
+            // Warm dual sticky across Ranges with idle timeout (not forever; not per-GET open).
             cacheBody = video,
             open = {
                 val openLane = {
@@ -446,6 +446,7 @@ object OpenFileExternally {
             displayName = displayName,
             mimeType = mimeType,
             sizeBytes = sizeBytes,
+            // Warm dual sticky + idle timeout (see ExternalHttpStreamServer.BACKEND_IDLE_MS).
             cacheBody = video,
             open = {
                 val openLane = {

--- a/app/src/main/kotlin/com/hippo/ehviewer/ui/OpenFileExternally.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/ui/OpenFileExternally.kt
@@ -165,19 +165,39 @@ object OpenFileExternally {
         else -> mimeTypeForFileName(name)
     }
 
-    private suspend fun buildHttpSession(
+    /**
+     * Obtain or reuse the HTTP session for [dirKey], then register media.
+     * Reused sessions keep the same id so folder playlist / next-file opens stay on one token.
+     */
+    private suspend fun withDirHttpSession(
         network: Boolean,
-        configure: suspend (ExternalHttpStreamServer.Session) -> Unit,
-    ): ExternalHttpStreamServer.Session {
-        val session = ExternalHttpStreamServer.newSession(network)
+        dirKey: String,
+        configure: suspend (ExternalHttpStreamServer.Session, reused: Boolean) -> Unit,
+    ): Pair<ExternalHttpStreamServer.Session, Boolean> {
+        val (session, reused) = ExternalHttpStreamServer.obtainSession(network, dirKey)
         return try {
-            configure(session)
-            session
+            configure(session, reused)
+            session to reused
         } catch (e: Throwable) {
-            ExternalHttpStreamServer.removeSession(session.id)
+            if (!reused) ExternalHttpStreamServer.removeSession(session.id)
             throw e
         }
     }
+
+    private fun localDirKey(videoPathStr: String): String {
+        val parent = if (videoPathStr.startsWith('/')) {
+            File(videoPathStr).parent ?: videoPathStr
+        } else {
+            runCatching { videoPathStr.toPath().parent?.toString() }.getOrNull() ?: videoPathStr
+        }
+        return "local:${parent.trimEnd('/')}"
+    }
+
+    private fun smbDirKey(sourceId: Long, parentDir: String): String =
+        "smb:$sourceId:${parentDir.trim().trimEnd('/')}"
+
+    private fun webDavDirKey(sourceId: Long, parentDir: String): String =
+        "dav:$sourceId:${parentDir.trim().trimEnd('/')}"
 
     private suspend fun openLocalVideoHttp(
         context: Context,
@@ -186,8 +206,9 @@ object OpenFileExternally {
         mimeType: String,
     ) {
         val accessDir = accessDirEnabled()
-        val session = withIOContext {
-            buildHttpSession(network = false) { session ->
+        val dirKey = localDirKey(pathStr)
+        val (session, reused) = withIOContext {
+            withDirHttpSession(network = false, dirKey = dirKey) { session, _ ->
                 session.put(localFileEntry(pathStr, displayName, mimeType))
                 // Only pre-listed files — no invent-on-GET for player subtitle probes.
                 val extras = if (accessDir) {
@@ -196,6 +217,7 @@ object OpenFileExternally {
                     findLocalSidecarNames(pathStr, displayName)
                 }
                 for (name in extras) {
+                    if (session.files.containsKey(ExternalHttpStreamServer.pathKey(name))) continue
                     val subPath = siblingPath(pathStr, name) ?: continue
                     runCatching {
                         session.put(localFileEntry(subPath, name, mediaMimeForName(name)))
@@ -205,12 +227,12 @@ object OpenFileExternally {
         }
         val videoUri = ExternalHttpStreamServer.uriFor(session.id, displayName)
         logcat("OpenFileExternally") {
-            "HTTP local video $videoUri files=${session.files.size} accessDir=$accessDir"
+            "HTTP local video $videoUri files=${session.files.size} accessDir=$accessDir reused=$reused"
         }
         try {
             launchHttpView(context, videoUri, displayName, mimeType, session, accessDir)
         } catch (e: Throwable) {
-            ExternalHttpStreamServer.removeSession(session.id)
+            if (!reused) ExternalHttpStreamServer.removeSession(session.id)
             throw e
         }
     }
@@ -224,26 +246,33 @@ object OpenFileExternally {
     ) {
         requestStreamNotificationPermission(context)
         val accessDir = accessDirEnabled()
-        val session = withIOContext {
+        val (session, reused) = withIOContext {
             val source = SmbRepository.load(sourceId) ?: throw IOException("SMB source missing")
             val password = SmbPasswordStore.get(sourceId)
             val sizeBytes = SmbGateway.fileSizeOrNull(source, password, remoteRelativeFile)
                 ?.takeIf { it > 0L }
                 ?: error("empty or unreachable file")
             val parentDir = parentRelative(remoteRelativeFile)
-            buildHttpSession(network = true) { session ->
+            val dirKey = smbDirKey(sourceId, parentDir)
+            withDirHttpSession(network = true, dirKey = dirKey) { session, wasReused ->
+                // Always refresh the opened video entry (known size).
                 session.put(
                     smbFileEntry(source, password, remoteRelativeFile, displayName, mimeType, sizeBytes),
                 )
-                // Pre-register only names that exist in the listing. Players invent .srt/.ass/.sami
-                // probes per video — resolveSibling must not open SMB for those (STATUS_OBJECT_NAME_NOT_FOUND spam).
+                // Pre-register only names that exist in the listing (no invent-on-GET for .srt probes).
                 val extras = if (accessDir) {
-                    listSmbDirMediaNames(sourceId, source, password, parentDir)
-                        .filterNot { it.equals(displayName, ignoreCase = true) }
+                    // Reuse: skip re-list when folder media already populated.
+                    if (wasReused && session.files.size > 1) {
+                        emptyList()
+                    } else {
+                        listSmbDirMediaNames(sourceId, source, password, parentDir)
+                            .filterNot { it.equals(displayName, ignoreCase = true) }
+                    }
                 } else {
                     findSmbSidecarNames(sourceId, source, password, remoteRelativeFile, displayName)
                 }
                 for (name in extras) {
+                    if (session.files.containsKey(ExternalHttpStreamServer.pathKey(name))) continue
                     val remote = SmbGateway.joinRelativePath(parentDir, name)
                     session.put(
                         smbFileEntry(
@@ -257,7 +286,8 @@ object OpenFileExternally {
                     )
                 }
                 logcat("OpenFileExternally") {
-                    "HTTP SMB session ${session.id} files=${session.files.size} accessDir=$accessDir"
+                    "HTTP SMB session ${session.id} files=${session.files.size} " +
+                        "accessDir=$accessDir reused=$wasReused dirKey=$dirKey"
                 }
             }
         }
@@ -265,7 +295,7 @@ object OpenFileExternally {
         try {
             launchHttpView(context, videoUri, displayName, mimeType, session, accessDir)
         } catch (e: Throwable) {
-            ExternalHttpStreamServer.removeSession(session.id)
+            if (!reused) ExternalHttpStreamServer.removeSession(session.id)
             throw e
         }
     }
@@ -279,25 +309,30 @@ object OpenFileExternally {
     ) {
         requestStreamNotificationPermission(context)
         val accessDir = accessDirEnabled()
-        val session = withIOContext {
+        val (session, reused) = withIOContext {
             val source = WebDavRepository.load(sourceId) ?: throw IOException("WebDAV source missing")
             val password = WebDavPasswordStore.get(sourceId)
             val sizeBytes = WebDavClient.fileSizeOrNull(source, password, remoteRelativeFile, sticky = true)
                 ?.takeIf { it > 0L }
                 ?: error("empty or unreachable file")
             val parentDir = parentRelative(remoteRelativeFile)
-            buildHttpSession(network = true) { session ->
+            val dirKey = webDavDirKey(sourceId, parentDir)
+            withDirHttpSession(network = true, dirKey = dirKey) { session, wasReused ->
                 session.put(
                     webDavFileEntry(source, password, remoteRelativeFile, displayName, mimeType, sizeBytes),
                 )
-                // Same as SMB: listing-only registration — no invent-on-GET for subtitle probes.
                 val extras = if (accessDir) {
-                    listWebDavDirMediaNames(sourceId, source, password, parentDir)
-                        .filterNot { it.equals(displayName, ignoreCase = true) }
+                    if (wasReused && session.files.size > 1) {
+                        emptyList()
+                    } else {
+                        listWebDavDirMediaNames(sourceId, source, password, parentDir)
+                            .filterNot { it.equals(displayName, ignoreCase = true) }
+                    }
                 } else {
                     findWebDavSidecarNames(sourceId, source, password, remoteRelativeFile, displayName)
                 }
                 for (name in extras) {
+                    if (session.files.containsKey(ExternalHttpStreamServer.pathKey(name))) continue
                     val remote = WebDavGateway.joinRelative(parentDir, name)
                     session.put(
                         webDavFileEntry(
@@ -310,13 +345,17 @@ object OpenFileExternally {
                         ),
                     )
                 }
+                logcat("OpenFileExternally") {
+                    "HTTP WebDAV session ${session.id} files=${session.files.size} " +
+                        "accessDir=$accessDir reused=$wasReused dirKey=$dirKey"
+                }
             }
         }
         val videoUri = ExternalHttpStreamServer.uriFor(session.id, displayName)
         try {
             launchHttpView(context, videoUri, displayName, mimeType, session, accessDir)
         } catch (e: Throwable) {
-            ExternalHttpStreamServer.removeSession(session.id)
+            if (!reused) ExternalHttpStreamServer.removeSession(session.id)
             throw e
         }
     }

--- a/app/src/main/kotlin/com/hippo/ehviewer/ui/OpenFileExternally.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/ui/OpenFileExternally.kt
@@ -558,7 +558,10 @@ object OpenFileExternally {
         // Full folder video list when access-dir is on.
         val videoNames = if (accessDir) {
             session.files.values
-                .filter { DefaultVideoPlayer.isVideoMime(it.mimeType) }
+                .filter {
+                    DefaultVideoPlayer.isVideoMime(it.mimeType) &&
+                        !it.displayName.equals(PLAYLIST_FILE_NAME, ignoreCase = true)
+                }
                 .map { it.displayName }
                 .distinct()
                 .sortedWith(String.CASE_INSENSITIVE_ORDER)
@@ -913,5 +916,5 @@ object OpenFileExternally {
 
     /** Virtual playlist basename served from the HTTP session (not a real on-disk file). */
     private const val PLAYLIST_FILE_NAME = "playlist.m3u8"
-    private const val PLAYLIST_MIME = "application/vnd.apple.mpegurl"
+    private const val PLAYLIST_MIME = "video/x-mpegurl"
 }

--- a/app/src/main/kotlin/com/hippo/ehviewer/ui/OpenFileExternally.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/ui/OpenFileExternally.kt
@@ -155,8 +155,7 @@ object OpenFileExternally {
      * When [accessDirEnabled] and this are on: intent data is a generated m3u8 of folder
      * videos (current first) instead of the single file URI + multi-file extras.
      */
-    private fun passFolderPlaylistEnabled(): Boolean =
-        accessDirEnabled() && Settings.externalVideoPassFolderPlaylist.value
+    private fun passFolderPlaylistEnabled(): Boolean = accessDirEnabled() && Settings.externalVideoPassFolderPlaylist.value
 
     private fun isHttpExposedMediaName(name: String): Boolean = isBrowseVideoFileName(name) || SidecarSubtitles.isSubtitleFileName(name)
 
@@ -193,11 +192,12 @@ object OpenFileExternally {
         return "local:${parent.trimEnd('/')}"
     }
 
-    private fun smbDirKey(sourceId: Long, parentDir: String): String =
-        "smb:$sourceId:${parentDir.trim().trimEnd('/')}"
+    private fun smbDirKey(sourceId: Long, parentDir: String): String = "smb:$sourceId:${parentDir.trim().trimEnd('/')}"
 
-    private fun webDavDirKey(sourceId: Long, parentDir: String): String =
-        "dav:$sourceId:${parentDir.trim().trimEnd('/')}"
+    private fun webDavDirKey(sourceId: Long, parentDir: String): String = "dav:$sourceId:${parentDir.trim().trimEnd('/')}"
+
+    /** Folder access shares one token; restricted access keeps one token per opened video. */
+    private fun httpSessionKey(dirKey: String, accessDir: Boolean, displayName: String): String = if (accessDir) "$dirKey|folder" else "$dirKey|file:${displayName.length}:$displayName"
 
     private suspend fun openLocalVideoHttp(
         context: Context,
@@ -206,7 +206,7 @@ object OpenFileExternally {
         mimeType: String,
     ) {
         val accessDir = accessDirEnabled()
-        val dirKey = localDirKey(pathStr)
+        val dirKey = httpSessionKey(localDirKey(pathStr), accessDir, displayName)
         val (session, reused) = withIOContext {
             withDirHttpSession(network = false, dirKey = dirKey) { session, _ ->
                 session.put(localFileEntry(pathStr, displayName, mimeType))
@@ -253,7 +253,7 @@ object OpenFileExternally {
                 ?.takeIf { it > 0L }
                 ?: error("empty or unreachable file")
             val parentDir = parentRelative(remoteRelativeFile)
-            val dirKey = smbDirKey(sourceId, parentDir)
+            val dirKey = httpSessionKey(smbDirKey(sourceId, parentDir), accessDir, displayName)
             withDirHttpSession(network = true, dirKey = dirKey) { session, wasReused ->
                 // Always refresh the opened video entry (known size).
                 session.put(
@@ -316,7 +316,7 @@ object OpenFileExternally {
                 ?.takeIf { it > 0L }
                 ?: error("empty or unreachable file")
             val parentDir = parentRelative(remoteRelativeFile)
-            val dirKey = webDavDirKey(sourceId, parentDir)
+            val dirKey = httpSessionKey(webDavDirKey(sourceId, parentDir), accessDir, displayName)
             withDirHttpSession(network = true, dirKey = dirKey) { session, wasReused ->
                 session.put(
                     webDavFileEntry(source, password, remoteRelativeFile, displayName, mimeType, sizeBytes),
@@ -599,11 +599,12 @@ object OpenFileExternally {
             .map { ExternalHttpStreamServer.uriFor(session.id, it.displayName) }
         val subNames = subUris.mapNotNull { it.lastPathSegment?.let { s -> Uri.decode(s) } }.toTypedArray()
         // Full folder video list when access-dir is on.
+        val playlistName = playlistNameFor(session.id)
         val videoNames = if (accessDir) {
             session.files.values
                 .filter {
                     DefaultVideoPlayer.isVideoMime(it.mimeType) &&
-                        !it.displayName.equals(PLAYLIST_FILE_NAME, ignoreCase = true)
+                        !it.displayName.equals(playlistName, ignoreCase = true)
                 }
                 .map { it.displayName }
                 .distinct()
@@ -622,13 +623,13 @@ object OpenFileExternally {
             val body = buildM3u8Playlist(session.id, videoNames, displayName)
             session.put(
                 ExternalHttpStreamServer.FileEntry(
-                    displayName = PLAYLIST_FILE_NAME,
+                    displayName = playlistName,
                     mimeType = PLAYLIST_MIME,
                     sizeBytes = body.size.toLong(),
                     open = { ExternalHttpStreamServer.BytesBody(body) },
                 ),
             )
-            openUri = ExternalHttpStreamServer.uriFor(session.id, PLAYLIST_FILE_NAME)
+            openUri = ExternalHttpStreamServer.uriFor(session.id, playlistName)
             openMime = PLAYLIST_MIME
             openTitle = displayName
             logcat("OpenFileExternally") {
@@ -684,7 +685,6 @@ object OpenFileExternally {
                 context.startActivity(chooser)
             } catch (e: ActivityNotFoundException) {
                 logcat("OpenFileExternally", e)
-                ExternalHttpStreamServer.removeSession(session.id)
                 error(context.getString(R.string.browse_open_failed))
             }
         }
@@ -958,6 +958,7 @@ object OpenFileExternally {
     private const val MAX_DIR_MEDIA_FILES = 80
 
     /** Virtual playlist basename served from the HTTP session (not a real on-disk file). */
-    private const val PLAYLIST_FILE_NAME = "playlist.m3u8"
+    private fun playlistNameFor(sessionId: String): String = ".localviewer-$sessionId.m3u8"
+
     private const val PLAYLIST_MIME = "video/x-mpegurl"
 }

--- a/app/src/main/kotlin/com/hippo/ehviewer/ui/OpenFileExternally.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/ui/OpenFileExternally.kt
@@ -165,15 +165,6 @@ object OpenFileExternally {
         else -> mimeTypeForFileName(name)
     }
 
-    private fun canResolveSibling(videoName: String, candidateName: String, accessDir: Boolean): Boolean {
-        if (!ExternalHttpStreamServer.isSafeFileName(candidateName)) return false
-        return if (accessDir) {
-            isHttpExposedMediaName(candidateName)
-        } else {
-            SidecarSubtitles.isSidecarFor(videoName, candidateName)
-        }
-    }
-
     private suspend fun buildHttpSession(
         network: Boolean,
         configure: suspend (ExternalHttpStreamServer.Session) -> Unit,
@@ -198,13 +189,7 @@ object OpenFileExternally {
         val session = withIOContext {
             buildHttpSession(network = false) { session ->
                 session.put(localFileEntry(pathStr, displayName, mimeType))
-                session.resolveSibling = resolve@{ name ->
-                    if (!canResolveSibling(displayName, name, accessDir)) return@resolve null
-                    val subPath = siblingPath(pathStr, name) ?: return@resolve null
-                    runCatching {
-                        localFileEntry(subPath, name, mediaMimeForName(name))
-                    }.getOrNull()
-                }
+                // Only pre-listed files — no invent-on-GET for player subtitle probes.
                 val extras = if (accessDir) {
                     listLocalDirMediaNames(pathStr).filterNot { it.equals(displayName, ignoreCase = true) }
                 } else {
@@ -250,21 +235,9 @@ object OpenFileExternally {
                 session.put(
                     smbFileEntry(source, password, remoteRelativeFile, displayName, mimeType, sizeBytes),
                 )
-                session.resolveSibling = resolve@{ name ->
-                    // HTTP worker thread — register name only; size resolved on first GET.
-                    if (!canResolveSibling(displayName, name, accessDir)) return@resolve null
-                    val remote = SmbGateway.joinRelativePath(parentDir, name)
-                    smbFileEntry(
-                        source,
-                        password,
-                        remote,
-                        name,
-                        mediaMimeForName(name),
-                        sizeBytes = -1L,
-                    )
-                }
+                // Pre-register only names that exist in the listing. Players invent .srt/.ass/.sami
+                // probes per video — resolveSibling must not open SMB for those (STATUS_OBJECT_NAME_NOT_FOUND spam).
                 val extras = if (accessDir) {
-                    // Names only — no per-file size probe (was O(n) RTTs before player start).
                     listSmbDirMediaNames(sourceId, source, password, parentDir)
                         .filterNot { it.equals(displayName, ignoreCase = true) }
                 } else {
@@ -272,18 +245,16 @@ object OpenFileExternally {
                 }
                 for (name in extras) {
                     val remote = SmbGateway.joinRelativePath(parentDir, name)
-                    runCatching {
-                        session.put(
-                            smbFileEntry(
-                                source,
-                                password,
-                                remote,
-                                name,
-                                mediaMimeForName(name),
-                                sizeBytes = -1L,
-                            ),
-                        )
-                    }.onFailure { logcat("OpenFileExternally", it) }
+                    session.put(
+                        smbFileEntry(
+                            source,
+                            password,
+                            remote,
+                            name,
+                            mediaMimeForName(name),
+                            sizeBytes = -1L,
+                        ),
+                    )
                 }
                 logcat("OpenFileExternally") {
                     "HTTP SMB session ${session.id} files=${session.files.size} accessDir=$accessDir"
@@ -319,18 +290,7 @@ object OpenFileExternally {
                 session.put(
                     webDavFileEntry(source, password, remoteRelativeFile, displayName, mimeType, sizeBytes),
                 )
-                session.resolveSibling = resolve@{ name ->
-                    if (!canResolveSibling(displayName, name, accessDir)) return@resolve null
-                    val remote = WebDavGateway.joinRelative(parentDir, name)
-                    webDavFileEntry(
-                        source,
-                        password,
-                        remote,
-                        name,
-                        mediaMimeForName(name),
-                        sizeBytes = -1L,
-                    )
-                }
+                // Same as SMB: listing-only registration — no invent-on-GET for subtitle probes.
                 val extras = if (accessDir) {
                     listWebDavDirMediaNames(sourceId, source, password, parentDir)
                         .filterNot { it.equals(displayName, ignoreCase = true) }
@@ -339,18 +299,16 @@ object OpenFileExternally {
                 }
                 for (name in extras) {
                     val remote = WebDavGateway.joinRelative(parentDir, name)
-                    runCatching {
-                        session.put(
-                            webDavFileEntry(
-                                source,
-                                password,
-                                remote,
-                                name,
-                                mediaMimeForName(name),
-                                sizeBytes = -1L,
-                            ),
-                        )
-                    }.onFailure { logcat("OpenFileExternally", it) }
+                    session.put(
+                        webDavFileEntry(
+                            source,
+                            password,
+                            remote,
+                            name,
+                            mediaMimeForName(name),
+                            sizeBytes = -1L,
+                        ),
+                    )
                 }
             }
         }
@@ -505,13 +463,8 @@ object OpenFileExternally {
         videoName: String,
     ): List<String> {
         val parentDir = parentRelative(remoteRelativeFile)
-        val names = siblingNamesFromCache(sourceId, parentDir, smb = true)
-            .ifEmpty {
-                SidecarSubtitles.probeCandidateNames(videoName).filter { name ->
-                    val remote = SmbGateway.joinRelativePath(parentDir, name)
-                    SmbGateway.fileSizeOrNull(source, password, remote)?.let { it > 0L } == true
-                }
-            }
+        // One directory list — never probeCandidateNames × fileSize (hundreds of NOT_FOUND opens).
+        val names = listSmbDirChildNames(sourceId, source, password, parentDir)
         return SidecarSubtitles.matchSiblings(videoName, names)
     }
 
@@ -520,25 +473,30 @@ object OpenFileExternally {
         source: SmbSourceEntity,
         password: String,
         parentDir: String,
+    ): List<String> = listSmbDirChildNames(sourceId, source, password, parentDir)
+        .filter { isHttpExposedMediaName(it) }
+        .distinct()
+        .sorted()
+        .take(MAX_DIR_MEDIA_FILES)
+
+    private suspend fun listSmbDirChildNames(
+        sourceId: Long,
+        source: SmbSourceEntity,
+        password: String,
+        parentDir: String,
     ): List<String> {
-        val names = siblingNamesFromCache(sourceId, parentDir, smb = true)
-            .ifEmpty {
-                runCatching {
-                    SmbGateway.listDirectory(source, password, parentDir, useCache = true)
-                        .mapNotNull { e ->
-                            when (e) {
-                                is BrowseEntryRemote.RegularFile -> directChildName(e.fileName)
-                                is BrowseEntryRemote.VideoFile -> directChildName(e.fileName)
-                                else -> null
-                            }
-                        }
-                }.getOrDefault(emptyList())
-            }
-        return names
-            .filter { isHttpExposedMediaName(it) }
-            .distinct()
-            .sorted()
-            .take(MAX_DIR_MEDIA_FILES)
+        val cached = siblingNamesFromCache(sourceId, parentDir, smb = true)
+        if (cached.isNotEmpty()) return cached
+        return runCatching {
+            SmbGateway.listDirectory(source, password, parentDir, useCache = true)
+                .mapNotNull { e ->
+                    when (e) {
+                        is BrowseEntryRemote.RegularFile -> directChildName(e.fileName)
+                        is BrowseEntryRemote.VideoFile -> directChildName(e.fileName)
+                        else -> null
+                    }
+                }
+        }.getOrDefault(emptyList())
     }
 
     private suspend fun findWebDavSidecarNames(
@@ -549,15 +507,28 @@ object OpenFileExternally {
         videoName: String,
     ): List<String> {
         val parentDir = parentRelative(remoteRelativeFile)
-        val names = siblingNamesFromCache(sourceId, parentDir, smb = false)
-            .ifEmpty {
-                SidecarSubtitles.probeCandidateNames(videoName).filter { name ->
-                    val remote = WebDavGateway.joinRelative(parentDir, name)
-                    WebDavClient.fileSizeOrNull(source, password, remote, sticky = true)
-                        ?.let { it > 0L } == true
-                }
-            }
+        val names = listWebDavDirChildNames(sourceId, source, password, parentDir)
         return SidecarSubtitles.matchSiblings(videoName, names)
+    }
+
+    private suspend fun listWebDavDirChildNames(
+        sourceId: Long,
+        source: WebDavSourceEntity,
+        password: String,
+        parentDir: String,
+    ): List<String> {
+        val cached = siblingNamesFromCache(sourceId, parentDir, smb = false)
+        if (cached.isNotEmpty()) return cached
+        return runCatching {
+            WebDavGateway.listDirectory(source, password, parentDir)
+                .mapNotNull { e ->
+                    when (e) {
+                        is BrowseEntryRemote.RegularFile -> directChildName(e.fileName)
+                        is BrowseEntryRemote.VideoFile -> directChildName(e.fileName)
+                        else -> null
+                    }
+                }
+        }.getOrDefault(emptyList())
     }
 
     private suspend fun listWebDavDirMediaNames(
@@ -566,19 +537,7 @@ object OpenFileExternally {
         password: String,
         parentDir: String,
     ): List<String> {
-        val names = siblingNamesFromCache(sourceId, parentDir, smb = false)
-            .ifEmpty {
-                runCatching {
-                    WebDavGateway.listDirectory(source, password, parentDir)
-                        .mapNotNull { e ->
-                            when (e) {
-                                is BrowseEntryRemote.RegularFile -> directChildName(e.fileName)
-                                is BrowseEntryRemote.VideoFile -> directChildName(e.fileName)
-                                else -> null
-                            }
-                        }
-                }.getOrDefault(emptyList())
-            }
+        val names = listWebDavDirChildNames(sourceId, source, password, parentDir)
         return names
             .filter { isHttpExposedMediaName(it) }
             .distinct()

--- a/app/src/main/kotlin/com/hippo/ehviewer/ui/OpenFileExternally.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/ui/OpenFileExternally.kt
@@ -151,6 +151,13 @@ object OpenFileExternally {
      */
     private fun accessDirEnabled(): Boolean = Settings.externalVideoAccessDir.value
 
+    /**
+     * When [accessDirEnabled] and this are on: intent data is a generated m3u8 of folder
+     * videos (current first) instead of the single file URI + multi-file extras.
+     */
+    private fun passFolderPlaylistEnabled(): Boolean =
+        accessDirEnabled() && Settings.externalVideoPassFolderPlaylist.value
+
     private fun isHttpExposedMediaName(name: String): Boolean = isBrowseVideoFileName(name) || SidecarSubtitles.isSubtitleFileName(name)
 
     private fun mediaMimeForName(name: String): String = when {
@@ -548,32 +555,62 @@ object OpenFileExternally {
             .sortedWith(compareBy(String.CASE_INSENSITIVE_ORDER) { it.displayName })
             .map { ExternalHttpStreamServer.uriFor(session.id, it.displayName) }
         val subNames = subUris.mapNotNull { it.lastPathSegment?.let { s -> Uri.decode(s) } }.toTypedArray()
-        // Full folder playlist when access-dir is on.
-        val videoUris = if (accessDir) {
+        // Full folder video list when access-dir is on.
+        val videoNames = if (accessDir) {
             session.files.values
                 .filter { DefaultVideoPlayer.isVideoMime(it.mimeType) }
                 .map { it.displayName }
-                .sorted()
-                .map { ExternalHttpStreamServer.uriFor(session.id, it) }
+                .distinct()
+                .sortedWith(String.CASE_INSENSITIVE_ORDER)
         } else {
             emptyList()
         }
-        val view = DefaultVideoPlayer.videoViewIntent(videoUri, mimeType).apply {
-            putExtra(Intent.EXTRA_TITLE, displayName)
-            val clip = ClipData.newRawUri(displayName, videoUri)
+        val videoUris = videoNames.map { ExternalHttpStreamServer.uriFor(session.id, it) }
+
+        // Optional: hand the whole folder as one m3u8 (VLC / mpv / etc.).
+        val passPlaylist = accessDir && passFolderPlaylistEnabled() && videoNames.isNotEmpty()
+        val openUri: Uri
+        val openMime: String
+        val openTitle: String
+        if (passPlaylist) {
+            val body = buildM3u8Playlist(session.id, videoNames, displayName)
+            session.put(
+                ExternalHttpStreamServer.FileEntry(
+                    displayName = PLAYLIST_FILE_NAME,
+                    mimeType = PLAYLIST_MIME,
+                    sizeBytes = body.size.toLong(),
+                    open = { ExternalHttpStreamServer.BytesBody(body) },
+                ),
+            )
+            openUri = ExternalHttpStreamServer.uriFor(session.id, PLAYLIST_FILE_NAME)
+            openMime = PLAYLIST_MIME
+            openTitle = displayName
+            logcat("OpenFileExternally") {
+                "HTTP folder m3u8 $openUri videos=${videoNames.size} start=$displayName"
+            }
+        } else {
+            openUri = videoUri
+            openMime = mimeType
+            openTitle = displayName
+        }
+
+        val view = DefaultVideoPlayer.videoViewIntent(openUri, openMime).apply {
+            putExtra(Intent.EXTRA_TITLE, openTitle)
+            val clip = ClipData.newRawUri(openTitle, openUri)
             for (i in subUris.indices) {
                 clip.addItem(ClipData.Item(subNames.getOrNull(i), null, subUris[i]))
             }
-            if (accessDir) {
+            // Multi-URI clip only when not using m3u8 (playlist file is the handoff).
+            if (accessDir && !passPlaylist) {
                 for (u in videoUris) {
-                    if (u != videoUri) clip.addItem(ClipData.Item(u))
+                    if (u != openUri) clip.addItem(ClipData.Item(u))
                 }
             }
             if (clip.itemCount > 1) clipData = clip
             if (subUris.isNotEmpty()) {
                 attachSubtitleExtras(subUris, subNames)
             }
-            if (videoUris.size > 1) {
+            if (!passPlaylist && videoUris.size > 1) {
                 attachPlaylistExtras(videoUris, displayName)
             }
         }
@@ -605,6 +642,37 @@ object OpenFileExternally {
                 error(context.getString(R.string.browse_open_failed))
             }
         }
+    }
+
+    /**
+     * Simple progressive m3u8 (not HLS segments): absolute HTTP URLs per video.
+     * Current file is listed first so players start there; remaining stay A–Z.
+     */
+    private fun buildM3u8Playlist(
+        sessionId: String,
+        videoNames: List<String>,
+        startName: String,
+    ): ByteArray {
+        val ordered = buildList {
+            val start = videoNames.firstOrNull { it.equals(startName, ignoreCase = true) }
+            if (start != null) {
+                add(start)
+                for (n in videoNames) {
+                    if (!n.equals(start, ignoreCase = true)) add(n)
+                }
+            } else {
+                addAll(videoNames)
+            }
+        }
+        val text = buildString(ordered.size * 96) {
+            append("#EXTM3U\n")
+            for (name in ordered) {
+                val title = name.replace('\r', ' ').replace('\n', ' ')
+                append("#EXTINF:-1,").append(title).append('\n')
+                append(ExternalHttpStreamServer.uriFor(sessionId, name)).append('\n')
+            }
+        }
+        return text.toByteArray(Charsets.UTF_8)
     }
 
     // endregion
@@ -842,4 +910,8 @@ object OpenFileExternally {
 
     /** Cap directory publish so open-with stays snappy on huge shares. */
     private const val MAX_DIR_MEDIA_FILES = 80
+
+    /** Virtual playlist basename served from the HTTP session (not a real on-disk file). */
+    private const val PLAYLIST_FILE_NAME = "playlist.m3u8"
+    private const val PLAYLIST_MIME = "application/vnd.apple.mpegurl"
 }

--- a/app/src/main/kotlin/com/hippo/ehviewer/ui/OpenFileExternally.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/ui/OpenFileExternally.kt
@@ -17,6 +17,7 @@ import com.hippo.ehviewer.Settings
 import com.hippo.ehviewer.library.BrowseEntryRemote
 import com.hippo.ehviewer.library.BrowseSession
 import com.hippo.ehviewer.library.SidecarSubtitles
+import com.hippo.ehviewer.library.VideoDirectLinkByteSource
 import com.hippo.ehviewer.library.isBrowseVideoFileName
 import com.hippo.ehviewer.library.mimeTypeForFileName
 import com.hippo.ehviewer.provider.ExternalHttpStreamServer
@@ -34,7 +35,6 @@ import com.hippo.ehviewer.webdav.WebDavPasswordStore
 import com.hippo.ehviewer.webdav.WebDavRepository
 import java.io.File
 import java.io.IOException
-import kotlinx.coroutines.runBlocking
 import okio.Path.Companion.toPath
 
 /**
@@ -250,18 +250,21 @@ object OpenFileExternally {
                 session.put(
                     smbFileEntry(source, password, remoteRelativeFile, displayName, mimeType, sizeBytes),
                 )
-                session.resolveSibling = { name ->
-                    // HTTP worker thread — blocking size probe is intentional.
-                    runBlocking {
-                        if (!canResolveSibling(displayName, name, accessDir)) return@runBlocking null
-                        val remote = SmbGateway.joinRelativePath(parentDir, name)
-                        val size = SmbGateway.fileSizeOrNull(source, password, remote)
-                            ?.takeIf { it > 0L }
-                            ?: return@runBlocking null
-                        smbFileEntry(source, password, remote, name, mediaMimeForName(name), size)
-                    }
+                session.resolveSibling = resolve@{ name ->
+                    // HTTP worker thread — register name only; size resolved on first GET.
+                    if (!canResolveSibling(displayName, name, accessDir)) return@resolve null
+                    val remote = SmbGateway.joinRelativePath(parentDir, name)
+                    smbFileEntry(
+                        source,
+                        password,
+                        remote,
+                        name,
+                        mediaMimeForName(name),
+                        sizeBytes = -1L,
+                    )
                 }
                 val extras = if (accessDir) {
+                    // Names only — no per-file size probe (was O(n) RTTs before player start).
                     listSmbDirMediaNames(sourceId, source, password, parentDir)
                         .filterNot { it.equals(displayName, ignoreCase = true) }
                 } else {
@@ -270,11 +273,15 @@ object OpenFileExternally {
                 for (name in extras) {
                     val remote = SmbGateway.joinRelativePath(parentDir, name)
                     runCatching {
-                        val size = SmbGateway.fileSizeOrNull(source, password, remote)
-                            ?.takeIf { it > 0L }
-                            ?: return@runCatching
                         session.put(
-                            smbFileEntry(source, password, remote, name, mediaMimeForName(name), size),
+                            smbFileEntry(
+                                source,
+                                password,
+                                remote,
+                                name,
+                                mediaMimeForName(name),
+                                sizeBytes = -1L,
+                            ),
                         )
                     }.onFailure { logcat("OpenFileExternally", it) }
                 }
@@ -312,15 +319,17 @@ object OpenFileExternally {
                 session.put(
                     webDavFileEntry(source, password, remoteRelativeFile, displayName, mimeType, sizeBytes),
                 )
-                session.resolveSibling = { name ->
-                    runBlocking {
-                        if (!canResolveSibling(displayName, name, accessDir)) return@runBlocking null
-                        val remote = WebDavGateway.joinRelative(parentDir, name)
-                        val size = WebDavClient.fileSizeOrNull(source, password, remote, sticky = true)
-                            ?.takeIf { it > 0L }
-                            ?: return@runBlocking null
-                        webDavFileEntry(source, password, remote, name, mediaMimeForName(name), size)
-                    }
+                session.resolveSibling = resolve@{ name ->
+                    if (!canResolveSibling(displayName, name, accessDir)) return@resolve null
+                    val remote = WebDavGateway.joinRelative(parentDir, name)
+                    webDavFileEntry(
+                        source,
+                        password,
+                        remote,
+                        name,
+                        mediaMimeForName(name),
+                        sizeBytes = -1L,
+                    )
                 }
                 val extras = if (accessDir) {
                     listWebDavDirMediaNames(sourceId, source, password, parentDir)
@@ -331,11 +340,15 @@ object OpenFileExternally {
                 for (name in extras) {
                     val remote = WebDavGateway.joinRelative(parentDir, name)
                     runCatching {
-                        val size = WebDavClient.fileSizeOrNull(source, password, remote, sticky = true)
-                            ?.takeIf { it > 0L }
-                            ?: return@runCatching
                         session.put(
-                            webDavFileEntry(source, password, remote, name, mediaMimeForName(name), size),
+                            webDavFileEntry(
+                                source,
+                                password,
+                                remote,
+                                name,
+                                mediaMimeForName(name),
+                                sizeBytes = -1L,
+                            ),
                         )
                     }.onFailure { logcat("OpenFileExternally", it) }
                 }
@@ -384,25 +397,41 @@ object OpenFileExternally {
         displayName: String,
         mimeType: String,
         sizeBytes: Long,
-    ) = ExternalHttpStreamServer.FileEntry(
-        displayName = displayName,
-        mimeType = mimeType,
-        sizeBytes = sizeBytes,
-        open = {
-            ExternalHttpStreamServer.ArchiveBody(
-                SmbArchiveByteSource(
-                    source = source,
-                    password = password,
-                    remoteRelativeFile = remoteRelativeFile,
-                    preferSequential = false,
-                    pipeline = false,
-                    stickySession = true,
-                    knownSize = sizeBytes,
-                    readahead = false,
-                ),
-            )
-        },
-    )
+    ): ExternalHttpStreamServer.FileEntry {
+        val video = DefaultVideoPlayer.isVideoMime(mimeType) || isBrowseVideoFileName(displayName)
+        return ExternalHttpStreamServer.FileEntry(
+            displayName = displayName,
+            mimeType = mimeType,
+            sizeBytes = sizeBytes,
+            // Dual sticky + sliding window; body reused across Ranges in the HTTP session.
+            cacheBody = video,
+            open = {
+                val openLane = {
+                    SmbArchiveByteSource(
+                        source = source,
+                        password = password,
+                        remoteRelativeFile = remoteRelativeFile,
+                        preferSequential = false,
+                        pipeline = false,
+                        stickySession = true,
+                        knownSize = sizeBytes.takeIf { it > 0L } ?: -1L,
+                        readahead = false,
+                    )
+                }
+                ExternalHttpStreamServer.ArchiveBody(
+                    if (video) {
+                        VideoDirectLinkByteSource.open(
+                            openLane = openLane,
+                            knownSize = sizeBytes,
+                            parallelPrefetch = true,
+                        )
+                    } else {
+                        openLane()
+                    },
+                )
+            },
+        )
+    }
 
     private fun webDavFileEntry(
         source: WebDavSourceEntity,
@@ -411,25 +440,40 @@ object OpenFileExternally {
         displayName: String,
         mimeType: String,
         sizeBytes: Long,
-    ) = ExternalHttpStreamServer.FileEntry(
-        displayName = displayName,
-        mimeType = mimeType,
-        sizeBytes = sizeBytes,
-        open = {
-            ExternalHttpStreamServer.ArchiveBody(
-                WebDavArchiveByteSource(
-                    source = source,
-                    password = password,
-                    remoteRelativeFile = remoteRelativeFile,
-                    preferSequential = false,
-                    pipeline = false,
-                    stickySession = true,
-                    knownSize = sizeBytes,
-                    readahead = false,
-                ),
-            )
-        },
-    )
+    ): ExternalHttpStreamServer.FileEntry {
+        val video = DefaultVideoPlayer.isVideoMime(mimeType) || isBrowseVideoFileName(displayName)
+        return ExternalHttpStreamServer.FileEntry(
+            displayName = displayName,
+            mimeType = mimeType,
+            sizeBytes = sizeBytes,
+            cacheBody = video,
+            open = {
+                val openLane = {
+                    WebDavArchiveByteSource(
+                        source = source,
+                        password = password,
+                        remoteRelativeFile = remoteRelativeFile,
+                        preferSequential = false,
+                        pipeline = false,
+                        stickySession = true,
+                        knownSize = sizeBytes.takeIf { it > 0L } ?: -1L,
+                        readahead = false,
+                    )
+                }
+                ExternalHttpStreamServer.ArchiveBody(
+                    if (video) {
+                        VideoDirectLinkByteSource.open(
+                            openLane = openLane,
+                            knownSize = sizeBytes,
+                            parallelPrefetch = true,
+                        )
+                    } else {
+                        openLane()
+                    },
+                )
+            },
+        )
+    }
 
     private fun findLocalSidecarNames(videoPathStr: String, videoName: String): List<String> {
         val siblings = findLocalSiblingNames(videoPathStr).ifEmpty {

--- a/app/src/main/kotlin/com/hippo/ehviewer/ui/screen/FolderBrowserScreen.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/ui/screen/FolderBrowserScreen.kt
@@ -359,10 +359,19 @@ fun AnimatedVisibilityScope.FolderBrowserScreen(
     /** History path link for the folder currently listed (parent of the opened file). */
     suspend fun recordCurrentBrowseFolderHistory() {
         val frame = stack.lastOrNull() ?: return
+        val parentPath = stack.getOrNull(stack.lastIndex - 1)?.path
+        val folderThumb = LocalHistory.localBrowseFolderThumbKey(
+            rootId = frame.rootId,
+            relativePath = frame.relativePath,
+            currentPath = frame.path,
+            entries = entries,
+            parentPath = parentPath,
+        )
         LocalHistory.recordLocalBrowseFolder(
             rootId = frame.rootId,
             relativePath = frame.relativePath,
             title = frame.title,
+            thumbKey = folderThumb,
         )
     }
 

--- a/app/src/main/kotlin/com/hippo/ehviewer/ui/screen/SmbBrowserScreen.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/ui/screen/SmbBrowserScreen.kt
@@ -462,10 +462,16 @@ fun AnimatedVisibilityScope.SmbBrowserScreen(
 
     /** History path link for the folder currently listed (parent of the opened file). */
     suspend fun recordCurrentBrowseFolderHistory(sourceId: Long) {
+        val folderThumb = LocalHistory.smbBrowseFolderThumbKey(
+            sourceId = sourceId,
+            relativeDir = relativeDir,
+            entries = entries,
+        )
         LocalHistory.recordSmbBrowseFolder(
             sourceId = sourceId,
             relativePath = relativeDir,
             title = title,
+            thumbKey = folderThumb,
         )
     }
 

--- a/app/src/main/kotlin/com/hippo/ehviewer/ui/screen/WebDavBrowserScreen.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/ui/screen/WebDavBrowserScreen.kt
@@ -463,10 +463,16 @@ fun AnimatedVisibilityScope.WebDavBrowserScreen(
 
     /** History path link for the folder currently listed (parent of the opened file). */
     suspend fun recordCurrentBrowseFolderHistory(sourceId: Long) {
+        val folderThumb = LocalHistory.webDavBrowseFolderThumbKey(
+            sourceId = sourceId,
+            relativeDir = relativeDir,
+            entries = entries,
+        )
         LocalHistory.recordWebDavBrowseFolder(
             sourceId = sourceId,
             relativePath = relativeDir,
             title = title,
+            thumbKey = folderThumb,
         )
     }
 

--- a/app/src/main/kotlin/com/hippo/ehviewer/ui/settings/EhScreen.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/ui/settings/EhScreen.kt
@@ -153,11 +153,19 @@ fun AnimatedVisibilityScope.EhScreen(navigator: DestinationsNavigator) = Screen(
                     }
                 }
             }
+            val externalVideoAccessDir = Settings.externalVideoAccessDir.asMutableState()
             SwitchPreference(
                 title = stringResource(id = R.string.settings_external_video_access_dir),
                 summary = stringResource(id = R.string.settings_external_video_access_dir_summary),
-                state = Settings.externalVideoAccessDir.asMutableState(),
+                state = externalVideoAccessDir,
             )
+            AnimatedVisibility(visible = externalVideoAccessDir.value) {
+                SwitchPreference(
+                    title = stringResource(id = R.string.settings_external_video_pass_folder_playlist),
+                    summary = stringResource(id = R.string.settings_external_video_pass_folder_playlist_summary),
+                    state = Settings.externalVideoPassFolderPlaylist.asMutableState(),
+                )
+            }
             val showSmallGalleries = Settings.browseShowSmallGalleries.asMutableState()
             SwitchPreference(
                 title = stringResource(id = R.string.settings_browse_menu_small_galleries),

--- a/core/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/core/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -72,8 +72,8 @@
     <string name="settings_default_video_player">Default video player</string>
     <string name="settings_default_video_player_always_ask">Always ask</string>
     <string name="settings_default_video_player_none">No video apps found</string>
-    <string name="settings_external_video_access_dir">Open folder with video player</string>
-    <string name="settings_external_video_access_dir_summary">Off: open only this video and matching subtitles. On: expose the whole folder (all videos and subtitles) so the player can use playlist / next-prev.</string>
+    <string name="settings_external_video_access_dir">Video player folder access</string>
+    <string name="settings_external_video_access_dir_summary">Allow external apps to access the current folder over local HTTP for video playlist support</string>
     <string name="browse_menu_page_count">Page count</string>
     <string name="browse_menu_reading_progress">Reading progress</string>
     <string name="browse_menu_small_galleries">Small galleries</string>

--- a/core/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/core/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -74,6 +74,8 @@
     <string name="settings_default_video_player_none">No video apps found</string>
     <string name="settings_external_video_access_dir">Video player folder access</string>
     <string name="settings_external_video_access_dir_summary">Allow external apps to access the current folder over local HTTP for video playlist support</string>
+    <string name="settings_external_video_pass_folder_playlist">Pass folder as playlist</string>
+    <string name="settings_external_video_pass_folder_playlist_summary">Open folder videos as an m3u8 playlist in the external player</string>
     <string name="browse_menu_page_count">Page count</string>
     <string name="browse_menu_reading_progress">Reading progress</string>
     <string name="browse_menu_small_galleries">Small galleries</string>

--- a/core/i18n/src/commonMain/moko-resources/zh-rCN/strings.xml
+++ b/core/i18n/src/commonMain/moko-resources/zh-rCN/strings.xml
@@ -70,6 +70,8 @@
     <string name="settings_default_video_player_none">未找到视频应用</string>
     <string name="settings_external_video_access_dir">允许 localhost 访问当前文件夹</string>
     <string name="settings_external_video_access_dir_summary">允许其他应用通过 HTTP 访问当前目录中的视频文件（用于视频播放列表支持）。</string>
+    <string name="settings_external_video_pass_folder_playlist">将文件夹作为播放列表传递</string>
+    <string name="settings_external_video_pass_folder_playlist_summary">在外部播放器中以 m3u8 播放列表打开当前文件夹中的视频</string>
     <string name="browse_menu_page_count">页数</string>
     <string name="browse_menu_reading_progress">阅读进度</string>
     <string name="browse_menu_small_galleries">小图库</string>

--- a/core/i18n/src/commonMain/moko-resources/zh-rCN/strings.xml
+++ b/core/i18n/src/commonMain/moko-resources/zh-rCN/strings.xml
@@ -68,8 +68,8 @@
     <string name="settings_default_video_player">默认视频播放器</string>
     <string name="settings_default_video_player_always_ask">每次询问</string>
     <string name="settings_default_video_player_none">未找到视频应用</string>
-    <string name="settings_external_video_access_dir">用视频播放器打开文件夹</string>
-    <string name="settings_external_video_access_dir_summary">关闭：仅打开当前视频及匹配字幕。开启：向播放器暴露整个文件夹（全部视频与字幕，便于播放列表/上下集）。</string>
+    <string name="settings_external_video_access_dir">允许 localhost 访问当前文件夹</string>
+    <string name="settings_external_video_access_dir_summary">允许其他应用通过 HTTP 访问当前目录中的视频文件（用于视频播放列表支持）。</string>
     <string name="browse_menu_page_count">页数</string>
     <string name="browse_menu_reading_progress">阅读进度</string>
     <string name="browse_menu_small_galleries">小图库</string>

--- a/core/i18n/src/commonMain/moko-resources/zh-rTW/strings.xml
+++ b/core/i18n/src/commonMain/moko-resources/zh-rTW/strings.xml
@@ -72,8 +72,6 @@
     <string name="settings_default_video_player">預設影片播放器</string>
     <string name="settings_default_video_player_always_ask">每次詢問</string>
     <string name="settings_default_video_player_none">找不到影片應用</string>
-    <string name="settings_external_video_access_dir">用影片播放器開啟資料夾</string>
-    <string name="settings_external_video_access_dir_summary">關閉：僅開啟目前影片及匹配字幕。開啟：向播放器暴露整個資料夾（全部影片與字幕，便於播放清單／上下集）。</string>
     <string name="browse_menu_page_count">頁數</string>
     <string name="browse_menu_reading_progress">閱讀進度</string>
     <string name="browse_menu_small_galleries">小圖庫</string>

--- a/core/i18n/src/commonMain/moko-resources/zh-rTW/strings.xml
+++ b/core/i18n/src/commonMain/moko-resources/zh-rTW/strings.xml
@@ -72,6 +72,10 @@
     <string name="settings_default_video_player">預設影片播放器</string>
     <string name="settings_default_video_player_always_ask">每次詢問</string>
     <string name="settings_default_video_player_none">找不到影片應用</string>
+    <string name="settings_external_video_access_dir">允許 localhost 存取目前資料夾</string>
+    <string name="settings_external_video_access_dir_summary">允許其他應用透過本機 HTTP 存取目前目錄中的影片檔（用於播放清單支援）。</string>
+    <string name="settings_external_video_pass_folder_playlist">將資料夾作為播放清單傳遞</string>
+    <string name="settings_external_video_pass_folder_playlist_summary">在外部播放器中以 m3u8 播放清單開啟目前資料夾中的影片</string>
     <string name="browse_menu_page_count">頁數</string>
     <string name="browse_menu_reading_progress">閱讀進度</string>
     <string name="browse_menu_small_galleries">小圖庫</string>


### PR DESCRIPTION
## What changed

- redesign external SMB/WebDAV video handoff around stateless loopback HTTP Range sessions
- reuse folder-scoped sessions for playlist and next/previous playback
- add generated m3u8 folder handoff and persist folder history thumbnails
- keep network I/O alive with a foreground service only while either HTTP transfers or streamdoc proxy FDs are active
- retain warm network bodies briefly between Range requests, then release them on idle timeout

## Release hardening

- coordinate wake-lock and service-stop decisions across HTTP and streamdoc transports
- isolate restricted mode to one video plus matching subtitles instead of accumulating a whole folder
- serialize same-scope session creation and protect active/new sessions from the soft cap
- make cached body handles safe against repeated close
- preserve reused playback sessions when a later chooser launch fails
- use a session-unique generated playlist name so a real `playlist.m3u8` is never overwritten
- remove the unused on-demand sibling resolver and refresh lifecycle documentation

## Impact

External players can seek, resume, load sidecar subtitles, and navigate folder playlists over SMB/WebDAV without one transport accidentally stopping the shared foreground service used by another. Folder exposure now follows the user setting exactly.

## Validation

- branch is based on `test@e0e61d584603ee3a8d7dc7342004848fc16b5d49`
- release diff is 12 commits ahead of `main@d06a2eca3b343f54115f6efe79cc0077944fac31`
- `git diff --check` passes
- local Gradle validation is unavailable because Gradle 9.5.1 is not cached and the sandbox cannot reach `services.gradle.org`; GitHub Actions is the authoritative Java 26 / Spotless / release-build gate
